### PR TITLE
Minor change to generate_metadata_script.py to find bias files

### DIFF
--- a/reduction_scripts/extra_tools/generate_metadata_script.py
+++ b/reduction_scripts/extra_tools/generate_metadata_script.py
@@ -86,7 +86,7 @@ for obs in blue_obs:
         pass
     #---------------------------
     # 1 - bias frames
-    if imagetype == 'BIAS':
+    if (imagetype == 'BIAS') or (imagetype == 'ZERO'):
         blue_bias.append(obs)
     # 2 - quartz flats
     if imagetype == 'FLAT':
@@ -260,7 +260,7 @@ for obs in red_obs:
         pass
     #---------------------------
     # 1 - bias frames
-    if imagetype == 'BIAS':
+    if (imagetype == 'BIAS') or (imagetype == 'ZERO'):
         red_bias.append(obs)
     # 2 - quartz flats
     if imagetype == 'FLAT':

--- a/reduction_scripts/extra_tools/generate_metadata_script.py
+++ b/reduction_scripts/extra_tools/generate_metadata_script.py
@@ -86,7 +86,7 @@ for obs in blue_obs:
         pass
     #---------------------------
     # 1 - bias frames
-    if imagetype == 'ZERO':
+    if imagetype == 'BIAS':
         blue_bias.append(obs)
     # 2 - quartz flats
     if imagetype == 'FLAT':
@@ -260,7 +260,7 @@ for obs in red_obs:
         pass
     #---------------------------
     # 1 - bias frames
-    if imagetype == 'ZERO':
+    if imagetype == 'BIAS':
         red_bias.append(obs)
     # 2 - quartz flats
     if imagetype == 'FLAT':


### PR DESCRIPTION
Hi,
I had some observations taken 18th October 2023 and I noticed my bias frames weren't being picked up by `generate_metadata_script.py` because the IMAGETYP in the fits headers is called BIAS and not ZERO. Perhaps this is a change with recent observations. I've updated the `generate_metadata_script.py` file to look for either a BIAS or ZERO imagetype keyword.

Thanks,
Tania