### PR TITLE
Fix single threaded arc fit with bad pixels.

### DIFF
--- a/src/pywifes/wifes_wsol.py
+++ b/src/pywifes/wifes_wsol.py
@@ -293,7 +293,7 @@ def _get_gauss_arc_fit(fit_function,
         xfit = x[ifit_lo:ifit_hi]
         yfit = y[ifit_lo:ifit_hi]
 
-        if len(yfit) > 0 and len(numpy.nonzero(yfit > 0.2 * yfit.max())) > 0:
+        if len(yfit) > 0 and numpy.count_nonzero(yfit > 0.2 * yfit.max()) > 0:
             jobs.append((i, curr_ctr_guess, width_guess, xfit, yfit))
         else:
             fitted_centers[i] = float('nan')

--- a/src/pywifes/wifes_wsol.py
+++ b/src/pywifes/wifes_wsol.py
@@ -293,12 +293,11 @@ def _get_mpfit_arc_fit(subbed_arc_data,
         ifit_hi = int(curr_ctr_guess + 5 * width_guess)
         xfit = x[ifit_lo:ifit_hi]
         yfit = y[ifit_lo:ifit_hi]
-        try:
-            good_pix = numpy.nonzero(yfit > 0.2*yfit.max())[0]
-        except:
+
+        if len(numpy.nonzero(yfit > 0.2 * yfit.max())) == 0:
             fitted_centers[i] = float('nan')
-            continue
-        jobs.append( (i,curr_ctr_guess, width_guess, xfit, yfit) )
+        else:
+            jobs.append( (i,curr_ctr_guess, width_guess, xfit, yfit) )
 
     if len(jobs) > 0:
         if multithread: 


### PR DESCRIPTION
## Description
I ran into an issue while testing https://github.com/PyWiFeS/pipeline/pull/32. When running a particular test case multithreaded, I got different results to running single threaded. I traced the difference to the `if multithread: ` cases in `weighted_loggauss_arc_fit`.

Both single & multithreaded cases are run using a `jobs` list. Those jobs store a line index, and running `mpfit_gauss_line` or `lsq_gauss_line` on a job returns a tuple storing `(line index, center)`.

A job is made for each arc *except* arcs with bad pixels. In that case, the center is recorded as 'nan'.

So when we go to record the center for each arc, we need to skip the indexes containing bad pixels. To do that, we just need to read the line index of the job. The multithreaded case did this, but the single threaded case did not.

I've updated the single threaded case to follow the same procedure as the multithreaded case.

## Tests
I've run the new version in single threaded & multithreaded modes, and get the same results.

Here's an example compare single threaded runs before & after the fix:
![image](https://github.com/PyWiFeS/pipeline/assets/94426704/122b5d15-1389-452b-b9f9-8636e41eca1a)

Comparing multithreaded before & single threaded after:
![image](https://github.com/PyWiFeS/pipeline/assets/94426704/0fbc79a9-772d-42d4-b590-72d65032fee8)

I've done small refactors to the multithreaded case now, they pass too.