### PR TITLE
Data cube with astrometry

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The Python data reduction pipeline for WiFeS
   - The pipeline chooses the template automatically.
   - Users don't need to set anything in generate metadata or reduction scripts anymore.
   - Users can create their own `.JSON` file following the same structure with their preferred setup.
+- Astrometry in the data cubes is implemented (still some small offsets in RA and Dec that will be fixed)
+
 
 #### Known Problems
 - **Multiprocessing** not always works properly.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The Python data reduction pipeline for WiFeS
   - The pipeline chooses the template automatically.
   - Users don't need to set anything in generate metadata or reduction scripts anymore.
   - Users can create their own `.JSON` file following the same structure with their preferred setup.
-- Astrometry in the data cubes is implemented (still some small offsets in RA and Dec that will be fixed)
+- Astrometry is now implemented in the data cubes (still some small offsets in RA and Dec that will be fixed)
 
 
 #### Known Problems

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The Python data reduction pipeline for WiFeS
 
 **Note:** This version is in active development.
 
-### November 2023 Update
+### December 2023 Update
 #### How is this code different from the [master](https://github.com/PyWiFeS/pipeline/tree/master) PyWiFeS repository?
 - Updated to Python 3, with bug fixes and headers for the new telescope setup.
 - Cleaner repository (some defunct scripts to be removed).
@@ -16,7 +16,13 @@ The Python data reduction pipeline for WiFeS
   - Users can create their own `.JSON` file following the same structure with their preferred setup.
 
 #### Known Problems
-- Multiprocessing not always works properly.
+- **Multiprocessing** not always works properly.
+    - **Update Dec 2023**: Multiprocessing can be enabled by **linux users ONLY** so the pipeline will do the job faster. To enable the multithreading option, please follow these steps:
+        1. In your working directory, open the `.json` file that corresponds to the observing mode of tour data. That is, `params_class.json` for classic mode, or `params_ns.json` for nod-and-shuffle. The `.json` files should have been previously copied to your working directory in step 2 in "Running the Pipeline".
+        2. Set `"multithread": true` in all the cases. There should be a total of 6 `"multithread"`, 3 for each arm in the following steps: `"step": "wave_soln"`, `"step": "cosmic_rays"`, and `"step": "cube_gen"`.
+        3. Run the pipeline following the instructions below.
+    Please note that this option is **not available for MacOS or Windows** users. We are working on it. 
+
 
 ---
 
@@ -45,7 +51,7 @@ The Python data reduction pipeline for WiFeS
    cp /Users/.../pipeline/reduction_scripts/reduce_data.py /Users/.../my_folder/
    cp /Users/.../pipeline/reduction_scripts/*.json /Users/.../my_folder/
    ```
-3. Run `reduce_data.py`, giving the raw data directory as an input parameter. from `/Users/.../my_folder/` The pipeline will run both arms automatically and choose the observing mode by checking the headers.
+3. Run `reduce_data.py`, giving the raw data directory as an input parameter from `/Users/.../my_folder/`. The pipeline will run both arms automatically and choose the observing mode by checking the headers.
     ```sh
    python3 reduce_data.py my_raw_data
    ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The Python data reduction pipeline for WiFeS
 
 #### Known Problems
 - **Multiprocessing** not always works properly.
-    - **Update Dec 2023**: Multiprocessing can be enabled by **Linux users ONLY** so the pipeline will does the job faster. To enable the multithreading option, please follow these steps:
+    - **Update Dec 2023**: Multiprocessing can be enabled by **Linux users ONLY** so the pipeline *may* do the job faster. To enable the multithreading option, please follow these steps:
         1. In your working directory, open the `.json` file that corresponds to the observing mode of your data. That is, `params_class.json` for classic mode, or `params_ns.json` for nod-and-shuffle. The `.json` files should have been previously copied to your working directory in step 2 in "Running the Pipeline".
         2. Set `"multithread": true` in all the cases. There should be a total of 6 `"multithread"`, 3 for each of the blue and red arms in the following steps: `"step": "wave_soln"`, `"step": "cosmic_rays"`, and `"step": "cube_gen"`.
         3. Run the pipeline following the instructions below.

--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ The Python data reduction pipeline for WiFeS
 
 #### Known Problems
 - **Multiprocessing** not always works properly.
-    - **Update Dec 2023**: Multiprocessing can be enabled by **linux users ONLY** so the pipeline will do the job faster. To enable the multithreading option, please follow these steps:
-        1. In your working directory, open the `.json` file that corresponds to the observing mode of tour data. That is, `params_class.json` for classic mode, or `params_ns.json` for nod-and-shuffle. The `.json` files should have been previously copied to your working directory in step 2 in "Running the Pipeline".
-        2. Set `"multithread": true` in all the cases. There should be a total of 6 `"multithread"`, 3 for each arm in the following steps: `"step": "wave_soln"`, `"step": "cosmic_rays"`, and `"step": "cube_gen"`.
+    - **Update Dec 2023**: Multiprocessing can be enabled by **linux users ONLY** so the pipeline will does the job faster. To enable the multithreading option, please follow these steps:
+        1. In your working directory, open the `.json` file that corresponds to the observing mode of your data. That is, `params_class.json` for classic mode, or `params_ns.json` for nod-and-shuffle. The `.json` files should have been previously copied to your working directory in step 2 in "Running the Pipeline".
+        2. Set `"multithread": true` in all the cases. There should be a total of 6 `"multithread"`, 3 for each of the blue and red arms in the following steps: `"step": "wave_soln"`, `"step": "cosmic_rays"`, and `"step": "cube_gen"`.
         3. Run the pipeline following the instructions below.
-    Please note that this option is **not available for MacOS or Windows** users. We are working on it. 
+    
+    Please note that this option is **NOT available for MacOS or Windows** users. We are currently working on it. 
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The Python data reduction pipeline for WiFeS
 
 #### Known Problems
 - **Multiprocessing** not always works properly.
-    - **Update Dec 2023**: Multiprocessing can be enabled by **linux users ONLY** so the pipeline will does the job faster. To enable the multithreading option, please follow these steps:
+    - **Update Dec 2023**: Multiprocessing can be enabled by **Linux users ONLY** so the pipeline will does the job faster. To enable the multithreading option, please follow these steps:
         1. In your working directory, open the `.json` file that corresponds to the observing mode of your data. That is, `params_class.json` for classic mode, or `params_ns.json` for nod-and-shuffle. The `.json` files should have been previously copied to your working directory in step 2 in "Running the Pipeline".
         2. Set `"multithread": true` in all the cases. There should be a total of 6 `"multithread"`, 3 for each of the blue and red arms in the following steps: `"step": "wave_soln"`, `"step": "cosmic_rays"`, and `"step": "cube_gen"`.
         3. Run the pipeline following the instructions below.

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ The Python data reduction pipeline for WiFeS
     For this approach to work, you would instead need to install with `pip install -e .`
 
 ## Running the Pipeline
-1. Put all raw data and calibration files in the same directory: `/Users/.../my_folder/my_raw_data`
-2. Copy the reduce data script and `.json` files to the above-mentioned folder:
+1. Put all raw data and calibration files in the same directory: `/Users/.../my_directory/my_raw_data`
+2. Copy the reduce data script and `.json` files to the above-mentioned directory:
     ```sh
-   cp /Users/.../pipeline/reduction_scripts/reduce_data.py /Users/.../my_folder/
-   cp /Users/.../pipeline/reduction_scripts/*.json /Users/.../my_folder/
+   cp /Users/.../pipeline/reduction_scripts/reduce_data.py /Users/.../my_directory/
+   cp /Users/.../pipeline/reduction_scripts/*.json /Users/.../my_directory/
    ```
-3. Run `reduce_data.py`, giving the raw data directory as an input parameter from `/Users/.../my_folder/`. The pipeline will run both arms automatically and choose the observing mode by checking the headers.
+3. Run `reduce_data.py`, giving the raw data directory path as an input parameter from `/Users/.../my_directory/`. The pipeline will run both arms automatically and choose the observing mode by checking the headers.
     ```sh
    python3 reduce_data.py my_raw_data
    ```
@@ -62,7 +62,7 @@ The Python data reduction pipeline for WiFeS
 
 
 **DATA REDUCED:**
-The pipeline will automatically generate two directories for the reduced data: `/Users/.../my_folder/reduc_red` and `/Users/.../my_folder/reduc_blue` containing: 
+The pipeline will automatically generate two directories for the reduced data: `/Users/.../my_directory/reduc_red` and `/Users/.../my_directory/reduc_blue` containing: 
 - Master calibration files
 - The intermediate files generated during the data reduction named as `file_name.p00.fits, file_name.p01.fits, ..., file_name.p10.fits`  
 - Final data cubes named as `file_name.p11.fits`  

--- a/src/pywifes/pywifes.py
+++ b/src/pywifes/pywifes.py
@@ -3289,7 +3289,7 @@ def generate_wifes_3dcube(inimg, outimg):
                 obj_cube_var[:,:,nx-i-1] = curr_var
                 obj_cube_dq[:,:,nx-i-1] = curr_dq
     
-    # ASTROMETY: obtained from pointing
+    # ASTROMETRY: obtained from pointing
     # # Celestial coordinates
     ra_str = f[1].header['RA']
     dec_str = f[1].header['DEC']
@@ -3325,13 +3325,15 @@ def generate_wifes_3dcube(inimg, outimg):
     pc3_3 = 1.0
 
     # Equiv. to 1 pixel width in each axis' units
-    cdelt1 = -0.00027777777777778   # 1 arcsecond in degree
-    cdelt2 = 0.00027777777777778   # 1 arcsecond in degree
+    binning2 = int(f[0].header['CCDSUM'][2])
+    arsec_deg = 0.00027777777777778   # 1 arcsecond in degrees
+    cdelt1 = arsec_deg   
+    cdelt2 = arsec_deg/2*binning2  
     cdelt3 = dlam
 
-    # Central pixel: defined in the centre of the central pixel
-    crpix1 = 25/2 + 0.5  # Central pixel
-    crpix2 = 38/2 + 0.5 # Central pixel
+    # Central pixel: defined in the centre of the central pixel   
+    crpix1 = nx/2 + 0.5  # Central pixel
+    crpix2 = ny/2 + 0.5 # Central pixel
     crpix3 = 1
 
     # Axis units
@@ -3343,38 +3345,69 @@ def generate_wifes_3dcube(inimg, outimg):
     # DATA
     cube_hdu = pyfits.PrimaryHDU(obj_cube_data, header = f[0].header)
     # Add header info
-    cube_hdu.header.set('CROTA2',telpa, 'Telescope rotation angle (degrees)')
     cube_hdu.header.set('CRVAL1',crval1, 'Value at ref. pixel on axis 1 (degrees)')
     cube_hdu.header.set('CRVAL2',crval2, 'Value at ref. pixel on axis 2 (degrees)')
     cube_hdu.header.set('CTYPE1',ctype1, 'Type of co-ordinate on axis 1')
     cube_hdu.header.set('CTYPE2',ctype2, 'Type of co-ordinate on axis 2')
-    cube_hdu.header.set('CTYPE3',ctype3, 'Type of co-ordinate on axis 3')
     cube_hdu.header.set('CDELT1',cdelt1, 'RA axis pixel width (degrees)')
     cube_hdu.header.set('CDELT2',cdelt2, 'Dec axis pixel width (degrees)')
     cube_hdu.header.set('CRPIX1',crpix1, 'Reference pixel on axis 1')
     cube_hdu.header.set('CRPIX2',crpix2, 'Reference pixel on axis 2')
-    cube_hdu.header.set('CRPIX2',crpix2, 'Reference pixel on axis 2')
-    cube_hdu.header.set('CRPIX3',crpix3, 'Reference pixel on axis 3')    
-    cube_hdu.header.set('CRVAL3',lam0, 'Reference wavelength (Angstroms)')
-    cube_hdu.header.set('CDELT3',dlam, 'Wavelength step (Angstroms)')
+    cube_hdu.header.set('CRPIX2',crpix2, 'Reference pixel on axis 2')  
     cube_hdu.header.set('PC1_1',pc1_1, 'Transformation matrix element')
     cube_hdu.header.set('PC1_2',pc1_2, 'Transformation matrix element')
     cube_hdu.header.set('PC2_1',pc2_1, 'Transformation matrix element')
     cube_hdu.header.set('PC2_2',pc2_2, 'Transformation matrix element')
+    cube_hdu.header.set('CRVAL3',lam0, 'Reference wavelength (Angstroms)')
+    cube_hdu.header.set('CTYPE3',ctype3, 'Type of co-ordinate on axis 3')
+    cube_hdu.header.set('CDELT3',dlam, 'Wavelength step (Angstroms)')
+    cube_hdu.header.set('CRPIX3',crpix3, 'Reference pixel on wavelength (axis 3)')  
     #cube_hdu.header.set('PYWIFES',__version__, 'Pywifes version'))
     outfits = pyfits.HDUList([cube_hdu])
-    
+
     # VARIANCE
     var_hdu = pyfits.PrimaryHDU(obj_cube_var, header = f[0].header)
-    var_hdu.header.set('CRVAL3',lam0, 'Reference wavelength')
-    var_hdu.header.set('CDELT3',dlam, 'Wavelength step')
+    # Add header info
+    var_hdu.header.set('CRVAL1',crval1, 'Value at ref. pixel on axis 1 (degrees)')
+    var_hdu.header.set('CRVAL2',crval2, 'Value at ref. pixel on axis 2 (degrees)')
+    var_hdu.header.set('CTYPE1',ctype1, 'Type of co-ordinate on axis 1')
+    var_hdu.header.set('CTYPE2',ctype2, 'Type of co-ordinate on axis 2')
+    var_hdu.header.set('CDELT1',cdelt1, 'RA axis pixel width (degrees)')
+    var_hdu.header.set('CDELT2',cdelt2, 'Dec axis pixel width (degrees)')
+    var_hdu.header.set('CRPIX1',crpix1, 'Reference pixel on axis 1')
+    var_hdu.header.set('CRPIX2',crpix2, 'Reference pixel on axis 2')
+    var_hdu.header.set('CRPIX2',crpix2, 'Reference pixel on axis 2')  
+    var_hdu.header.set('PC1_1',pc1_1, 'Transformation matrix element')
+    var_hdu.header.set('PC1_2',pc1_2, 'Transformation matrix element')
+    var_hdu.header.set('PC2_1',pc2_1, 'Transformation matrix element')
+    var_hdu.header.set('PC2_2',pc2_2, 'Transformation matrix element')
+    var_hdu.header.set('CRVAL3',lam0, 'Reference wavelength (Angstroms)')
+    var_hdu.header.set('CTYPE3',ctype3, 'Type of co-ordinate on axis 3')
+    var_hdu.header.set('CDELT3',dlam, 'Wavelength step (Angstroms)')
+    var_hdu.header.set('CRPIX3',crpix3, 'Reference pixel on wavelength (axis 3)')  
     #var_hdu.header.set('PYWIFES',__version__, 'Pywifes version')
     outfits.append(var_hdu)
     
     # DQ
     dq_hdu = pyfits.PrimaryHDU(obj_cube_dq, header = f[0].header)
-    dq_hdu.header.set('CRVAL3',lam0, 'Reference wavelength')
-    dq_hdu.header.set('CDELT3',dlam, 'Wavelength step')
+    # Add header info
+    dq_hdu.header.set('CRVAL1',crval1, 'Value at ref. pixel on axis 1 (degrees)')
+    dq_hdu.header.set('CRVAL2',crval2, 'Value at ref. pixel on axis 2 (degrees)')
+    dq_hdu.header.set('CTYPE1',ctype1, 'Type of co-ordinate on axis 1')
+    dq_hdu.header.set('CTYPE2',ctype2, 'Type of co-ordinate on axis 2')
+    dq_hdu.header.set('CDELT1',cdelt1, 'RA axis pixel width (degrees)')
+    dq_hdu.header.set('CDELT2',cdelt2, 'Dec axis pixel width (degrees)')
+    dq_hdu.header.set('CRPIX1',crpix1, 'Reference pixel on axis 1')
+    dq_hdu.header.set('CRPIX2',crpix2, 'Reference pixel on axis 2')
+    dq_hdu.header.set('CRPIX2',crpix2, 'Reference pixel on axis 2')  
+    dq_hdu.header.set('PC1_1',pc1_1, 'Transformation matrix element')
+    dq_hdu.header.set('PC1_2',pc1_2, 'Transformation matrix element')
+    dq_hdu.header.set('PC2_1',pc2_1, 'Transformation matrix element')
+    dq_hdu.header.set('PC2_2',pc2_2, 'Transformation matrix element')
+    dq_hdu.header.set('CRVAL3',lam0, 'Reference wavelength (Angstroms)')
+    dq_hdu.header.set('CTYPE3',ctype3, 'Type of co-ordinate on axis 3')
+    dq_hdu.header.set('CDELT3',dlam, 'Wavelength step (Angstroms)')
+    dq_hdu.header.set('CRPIX3',crpix3, 'Reference pixel on wavelength (axis 3)')  
     #dq_hdu.header.set('PYWIFES',__version__, 'Pywifes version')
     outfits.append(dq_hdu)
     

--- a/src/pywifes/pywifes.py
+++ b/src/pywifes/pywifes.py
@@ -3295,8 +3295,8 @@ def generate_wifes_3dcube(inimg, outimg):
     dec_str = f[1].header['DEC']
     # Convert celestial coordinates to degrees
     coord = SkyCoord(ra=ra_str, dec=dec_str, unit=(u.hourangle, u.deg))
-    crval1 = coord.ra.deg +  0.00013888888888889 # + 0.5 arcsec in deg
-    crval2 = coord.dec.deg + 0.00055555555555556 # + 2 arcsec in deg
+    crval1 = coord.ra.deg 
+    crval2 = coord.dec.deg 
     crval3 = lam0
     
     # Set up a tangential projection

--- a/src/pywifes/pywifes.py
+++ b/src/pywifes/pywifes.py
@@ -3327,7 +3327,7 @@ def generate_wifes_3dcube(inimg, outimg):
     # Equiv. to 1 pixel width in each axis' units
     binning2 = int(f[0].header['CCDSUM'][2])
     arsec_deg = 0.00027777777777778   # 1 arcsecond in degrees
-    cdelt1 = arsec_deg   
+    cdelt1 = -arsec_deg   
     cdelt2 = arsec_deg/2*binning2  
     cdelt3 = dlam
 


### PR DESCRIPTION
We have implemented the astrometry in the data cubes. We can now identify the sources and the field of view in the sky region. However, some offsets are still present in both `RA` and `DEC` coordinates. The main reasons for these offsets are explained below. We plan to investigate how to improve the accuracy of the astrometry in a further PR.

We are using the `RA` and `DEC` values in the header of the '.fits' files. These coordinates are those of the science target and were provided by the observer. Also, these `RA` and `DEC` values should correspond to the centre of the IFU, and therefore in the centre of the image from the reduced cube. However, we see clear offsets from those positions. The reason for that is that the telescope pointing is calibrated using the acquisition star that was found and centred in the guide camera (not the IFU). Thus, the actual `RA` and `DEC` coordinates are defined by the relative difference between these positions.  However, applying those differences in the positions implies many small calibrated transformations that can contribute to errors. In addition, the accuracy of the coordinates supplied by the users can potentially increase the uncertainties of the astrometry, especially for high proper motion acquisition stars.

To implement the astrometry we have made changes in the `src/pywifes/pywifes.py` file in the `generate_wifes_3dcube` function. We have used the information in the headers of the files and some calculations, and then we saved the information in new keywords in the header of the data cubes files.

We also updated the information in the `README.md` file to account for the astrometry. The differences regarding the multithreading are due to the differences in the commits history.
