### PR TITLE
Easier way to run the pipeline locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,19 +48,17 @@ The Python data reduction pipeline for WiFeS
     2. Or run the command manually before 'Running the Pipeline'.
     3. Alternatively, if `PYWIFES_DIR` is not set, the pipeline searches the program's *install* directory.
     For this approach to work, you would instead need to install with `pip install -e .`
+4.  Set up an alias for the main reduction routine: 
+    ```sh
+    alias pywifes-reduce='/Users/.../pipeline/reduction_scripts/reduce_data.py'
+    ```    
 
 ## Running the Pipeline
 1. Put all raw data and calibration files in the same directory: `/Users/.../my_directory/my_raw_data`
-2. Copy the reduce data script and `.json` files to the above-mentioned directory:
+2. Run the main reduction routine, giving the raw data directory path as an input parameter. The pipeline will run both arms automatically and choose the observing mode by checking the headers.
     ```sh
-   cp /Users/.../pipeline/reduction_scripts/reduce_data.py /Users/.../my_directory/
-   cp /Users/.../pipeline/reduction_scripts/*.json /Users/.../my_directory/
+   pywifes-reduce my_raw_data
    ```
-3. Run `reduce_data.py`, giving the raw data directory path as an input parameter from `/Users/.../my_directory/`. The pipeline will run both arms automatically and choose the observing mode by checking the headers.
-    ```sh
-   python3 reduce_data.py my_raw_data
-   ```
-
 
 
 **DATA REDUCED:**

--- a/reduction_scripts/reduce_data.py
+++ b/reduction_scripts/reduce_data.py
@@ -785,10 +785,8 @@ def main():
         #      LOAD JSON FILE WITH USER REDUCTION SETUP             
         #------------------------------------------------------------------------
         obs_metadata = obs_metadatas[arm]
-        
         reduction_scripts_dir = os.path.dirname(__file__)
         working_dir = os.getcwd()
-        
 
         # Check observing mode
         sci_filename = obs_metadatas[arm]['sci'][0]['sci'][0]+'.fits'
@@ -802,9 +800,6 @@ def main():
 
         with open(file_path, 'r') as f:
             proc_steps = json.load(f)
-
-
-
 
         # Check if the reduc_blue/red folders already exists and create them if required
         out_dir = os.path.join(working_dir, f'reduc_{arm}') 

--- a/reduction_scripts/reduce_data.py
+++ b/reduction_scripts/reduce_data.py
@@ -785,8 +785,11 @@ def main():
         #      LOAD JSON FILE WITH USER REDUCTION SETUP             
         #------------------------------------------------------------------------
         obs_metadata = obs_metadatas[arm]
-        project_dir = os.path.dirname(__file__)
         
+        reduction_scripts_dir = os.path.dirname(__file__)
+        working_dir = os.getcwd()
+        
+
         # Check observing mode
         sci_filename = obs_metadatas[arm]['sci'][0]['sci'][0]+'.fits'
         if pywifes.is_nodshuffle(data_dir+sci_filename):
@@ -795,12 +798,16 @@ def main():
             obs_mode = 'class'    
 
         # Read the JSON file
-        file_path = f'params_{obs_mode}.json'  
+        file_path = os.path.join(reduction_scripts_dir, f'params_{obs_mode}.json')
+
         with open(file_path, 'r') as f:
             proc_steps = json.load(f)
 
+
+
+
         # Check if the reduc_blue/red folders already exists and create them if required
-        out_dir = os.path.join(project_dir, f'reduc_{arm}') 
+        out_dir = os.path.join(working_dir, f'reduc_{arm}') 
         if not os.path.exists(out_dir):
             os.mkdir(out_dir)
         else:

--- a/reduction_scripts/reduce_data.py
+++ b/reduction_scripts/reduce_data.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3 
 
 import sys
 import os


### PR DESCRIPTION
We have simplified the way to run the pipeline as follows:

1. Users do not have to copy/paste the `.JSON` files to the project directory. 
2. Same for `reduce_data.py`.
3. Updated info in `README.md` file accordingly, including a new step to set up an alias to execute the main data reduction routine `reduce_data.py` from the project directory doing: `pywifes-reduce my_raw_data`