### PR TITLE
Option added to pick the params_ns.json file for SubNodAndShuffle data

### DIFF
--- a/reduction_scripts/reduce_data.py
+++ b/reduction_scripts/reduce_data.py
@@ -791,6 +791,8 @@ def main():
         sci_filename = obs_metadatas[arm]['sci'][0]['sci'][0]+'.fits'
         if pywifes.is_nodshuffle(data_dir+sci_filename):
             obs_mode = 'ns'
+        elif pywifes.is_subnodshuffle(data_dir+sci_filename):
+            obs_mode = 'ns'
         else:
             obs_mode = 'class'    
 

--- a/src/pywifes/pywifes.py
+++ b/src/pywifes/pywifes.py
@@ -82,6 +82,12 @@ def is_nodshuffle(inimg, data_hdu=0):
     f.close()
     return ns == 'NodAndShuffle'
 
+def is_subnodshuffle(inimg, data_hdu=0):
+    f = pyfits.open(inimg)
+    ns = f[data_hdu].header['WIFESOBS']
+    f.close()
+    return ns == 'SubNodAndShuffle'
+
 
 #------------------------------------------------------------------------
 def imcombine(inimg_list, outimg,

--- a/src/pywifes/pywifes.py
+++ b/src/pywifes/pywifes.py
@@ -84,9 +84,9 @@ def is_nodshuffle(inimg, data_hdu=0):
 
 def is_subnodshuffle(inimg, data_hdu=0):
     f = pyfits.open(inimg)
-    ns = f[data_hdu].header['WIFESOBS']
+    sns = f[data_hdu].header['WIFESOBS']
     f.close()
-    return ns == 'SubNodAndShuffle'
+    return sns == 'SubNodAndShuffle'
 
 
 #------------------------------------------------------------------------


### PR DESCRIPTION
Added the validator function `is_subnodshuffle()` in `/src/pywifes/pywifes.py` to check whether the data were observed in sub nod and shuffle mode. This is then used in `/reduction_scripts/reduce_data.py` to choose the configuration file accordingly. That is, `if is_subnodshuffle() == True`, then the pipeline will use the `params_ns.json` file as the preferred recipe. 