### PR TITLE
Fixed twilight flats correction, wire solution in red arm and Python version to 3.10

### DIFF
--- a/reduction_scripts/pipeline_params/blue/params_class_B3000.json
+++ b/reduction_scripts/pipeline_params/blue/params_class_B3000.json
@@ -61,7 +61,7 @@
             "suffix": null,
             "args": {
                 "type": [
-                    "dome"
+                    "dome", "twi"
                 ],
                 "verbose": true,
                 "plot": false,

--- a/reduction_scripts/pipeline_params/blue/params_class_B7000.json
+++ b/reduction_scripts/pipeline_params/blue/params_class_B7000.json
@@ -61,7 +61,7 @@
             "suffix": null,
             "args": {
                 "type": [
-                    "dome"
+                    "dome", "twi"
                 ],
                 "verbose": true,
                 "plot": false,

--- a/reduction_scripts/pipeline_params/blue/params_class_U7000.json
+++ b/reduction_scripts/pipeline_params/blue/params_class_U7000.json
@@ -61,7 +61,7 @@
             "suffix": null,
             "args": {
                 "type": [
-                    "dome"
+                    "dome", "twi"
                 ],
                 "verbose": true,
                 "plot": false,

--- a/reduction_scripts/pipeline_params/blue/params_ns_B3000.json
+++ b/reduction_scripts/pipeline_params/blue/params_ns_B3000.json
@@ -61,7 +61,7 @@
             "suffix": null,
             "args": {
                 "type": [
-                    "dome"
+                    "dome", "twi"
                 ],
                 "verbose": true,
                 "plot": false,

--- a/reduction_scripts/pipeline_params/blue/params_ns_B7000.json
+++ b/reduction_scripts/pipeline_params/blue/params_ns_B7000.json
@@ -61,7 +61,7 @@
             "suffix": null,
             "args": {
                 "type": [
-                    "dome"
+                    "dome", "twi"
                 ],
                 "verbose": true,
                 "plot": false,

--- a/reduction_scripts/pipeline_params/blue/params_ns_U7000.json
+++ b/reduction_scripts/pipeline_params/blue/params_ns_U7000.json
@@ -61,7 +61,7 @@
             "suffix": null,
             "args": {
                 "type": [
-                    "dome"
+                    "dome", "twi"
                 ],
                 "verbose": true,
                 "plot": false,

--- a/reduction_scripts/pipeline_params/red/params_class_I7000.json
+++ b/reduction_scripts/pipeline_params/red/params_class_I7000.json
@@ -115,7 +115,7 @@
         },
         {
             "step": "wire_soln",
-            "run": false,
+            "run": true,
             "suffix": null,
             "args": {}
         },

--- a/reduction_scripts/pipeline_params/red/params_class_I7000.json
+++ b/reduction_scripts/pipeline_params/red/params_class_I7000.json
@@ -42,7 +42,7 @@
         },
         {
             "step": "superflat",
-            "run": false,
+            "run": true,
             "suffix": null,
             "args": {
                 "source": "twi",
@@ -61,7 +61,7 @@
             "suffix": null,
             "args": {
                 "type": [
-                    "dome"
+                    "dome", "twi"
                 ],
                 "verbose": true,
                 "plot": false,
@@ -84,7 +84,7 @@
         },
         {
             "step": "superflat_mef",
-            "run": false,
+            "run": true,
             "suffix": null,
             "args": {
                 "source": "twi"

--- a/reduction_scripts/pipeline_params/red/params_class_R3000.json
+++ b/reduction_scripts/pipeline_params/red/params_class_R3000.json
@@ -115,7 +115,7 @@
         },
         {
             "step": "wire_soln",
-            "run": false,
+            "run": true,
             "suffix": null,
             "args": {}
         },

--- a/reduction_scripts/pipeline_params/red/params_class_R3000.json
+++ b/reduction_scripts/pipeline_params/red/params_class_R3000.json
@@ -42,7 +42,7 @@
         },
         {
             "step": "superflat",
-            "run": false,
+            "run": true,
             "suffix": null,
             "args": {
                 "source": "twi",
@@ -61,7 +61,7 @@
             "suffix": null,
             "args": {
                 "type": [
-                    "dome"
+                    "dome", "twi"
                 ],
                 "verbose": true,
                 "plot": false,
@@ -84,7 +84,7 @@
         },
         {
             "step": "superflat_mef",
-            "run": false,
+            "run": true,
             "suffix": null,
             "args": {
                 "source": "twi"

--- a/reduction_scripts/pipeline_params/red/params_class_R7000.json
+++ b/reduction_scripts/pipeline_params/red/params_class_R7000.json
@@ -115,7 +115,7 @@
         },
         {
             "step": "wire_soln",
-            "run": false,
+            "run": true,
             "suffix": null,
             "args": {}
         },

--- a/reduction_scripts/pipeline_params/red/params_class_R7000.json
+++ b/reduction_scripts/pipeline_params/red/params_class_R7000.json
@@ -42,7 +42,7 @@
         },
         {
             "step": "superflat",
-            "run": false,
+            "run": true,
             "suffix": null,
             "args": {
                 "source": "twi",
@@ -61,7 +61,7 @@
             "suffix": null,
             "args": {
                 "type": [
-                    "dome"
+                    "dome", "twi"
                 ],
                 "verbose": true,
                 "plot": false,
@@ -84,7 +84,7 @@
         },
         {
             "step": "superflat_mef",
-            "run": false,
+            "run": true,
             "suffix": null,
             "args": {
                 "source": "twi"

--- a/reduction_scripts/pipeline_params/red/params_ns_I7000.json
+++ b/reduction_scripts/pipeline_params/red/params_ns_I7000.json
@@ -115,7 +115,7 @@
         },
         {
             "step": "wire_soln",
-            "run": false,
+            "run": true,
             "suffix": null,
             "args": {}
         },

--- a/reduction_scripts/pipeline_params/red/params_ns_I7000.json
+++ b/reduction_scripts/pipeline_params/red/params_ns_I7000.json
@@ -42,7 +42,7 @@
         },
         {
             "step": "superflat",
-            "run": false,
+            "run": true,
             "suffix": null,
             "args": {
                 "source": "twi",
@@ -61,7 +61,7 @@
             "suffix": null,
             "args": {
                 "type": [
-                    "dome"
+                    "dome", "twi"
                 ],
                 "verbose": true,
                 "plot": false,
@@ -84,7 +84,7 @@
         },
         {
             "step": "superflat_mef",
-            "run": false,
+            "run": true,
             "suffix": null,
             "args": {
                 "source": "twi"

--- a/reduction_scripts/pipeline_params/red/params_ns_R3000.json
+++ b/reduction_scripts/pipeline_params/red/params_ns_R3000.json
@@ -115,7 +115,7 @@
         },
         {
             "step": "wire_soln",
-            "run": false,
+            "run": true,
             "suffix": null,
             "args": {}
         },

--- a/reduction_scripts/pipeline_params/red/params_ns_R3000.json
+++ b/reduction_scripts/pipeline_params/red/params_ns_R3000.json
@@ -42,7 +42,7 @@
         },
         {
             "step": "superflat",
-            "run": false,
+            "run": true,
             "suffix": null,
             "args": {
                 "source": "twi",
@@ -61,7 +61,7 @@
             "suffix": null,
             "args": {
                 "type": [
-                    "dome"
+                    "dome", "twi"
                 ],
                 "verbose": true,
                 "plot": false,
@@ -84,7 +84,7 @@
         },
         {
             "step": "superflat_mef",
-            "run": false,
+            "run": true,
             "suffix": null,
             "args": {
                 "source": "twi"

--- a/reduction_scripts/pipeline_params/red/params_ns_R7000.json
+++ b/reduction_scripts/pipeline_params/red/params_ns_R7000.json
@@ -115,7 +115,7 @@
         },
         {
             "step": "wire_soln",
-            "run": false,
+            "run": true,
             "suffix": null,
             "args": {}
         },

--- a/reduction_scripts/pipeline_params/red/params_ns_R7000.json
+++ b/reduction_scripts/pipeline_params/red/params_ns_R7000.json
@@ -42,7 +42,7 @@
         },
         {
             "step": "superflat",
-            "run": false,
+            "run": true,
             "suffix": null,
             "args": {
                 "source": "twi",
@@ -61,7 +61,7 @@
             "suffix": null,
             "args": {
                 "type": [
-                    "dome"
+                    "dome", "twi"
                 ],
                 "verbose": true,
                 "plot": false,
@@ -84,7 +84,7 @@
         },
         {
             "step": "superflat_mef",
-            "run": false,
+            "run": true,
             "suffix": null,
             "args": {
                 "source": "twi"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version="0.7.4",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
-    python_requires=">=3.10",
+    python_requires="==3.10.*",
     install_requires=[
         "wheel",
         "setuptools",


### PR DESCRIPTION
A few issues fixed here. Tested the new features and all went well. Details below:

1. Fixed twilight flats correction: updated `.json` files to allow for twilight flats correction.

2. Enabled to do the wire solution in red arm: : updated `.json` files.

3. Python version fixed to 3.10: updated `setup.py` script