### PR TITLE
Fji reduction from masters

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,27 @@ The pipeline will generate the `data_products` directory within the working dire
 
 **User-Defined Reduction Parameters:**
 
+*Set reduction steps*
+
 To specify the reduction steps for blue and red data, users can provide the paths to the respective JSON files using the `--red-params` and `--blue-params` flags as follows:
    
 
     pywifes-reduce my_raw_data --red-params /Users/.../user_red_param_file.json --blue-params /Users/.../user_blue_param_file.json
+
+
+
+
+*Reduce Data Using Master Calibration Files*
+
+To perform data reduction using master calibration files from previous reductions, use the `--from-master` flag along with the path to the directory containing all calibration files. Both blue and red data should be stored together in the same directory for coherence. If no path is specified after the `--from-master` flag, the default directory `./data_products/master_calib` is assumed.
+
+    pywifes-reduce my_raw_data --from-master /Users/.../master_calibrations_directory
+
+
+*Other parameters*
+
+`-skip-done`: Skip already completed steps. 
+
 
 ### TO DO
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ To perform data reduction using master calibration files from previous reduction
 
 `-skip-done`: Skip already completed steps. 
 
+`-just-calib`: Triggers the data reduction in absence of on-sky data (both science and calibration). It only produce basic calibration files.
 
 ### TO DO
 

--- a/reduction_scripts/pipeline_params/just-calib/blue/params_class_B3000.json
+++ b/reduction_scripts/pipeline_params/just-calib/blue/params_class_B3000.json
@@ -1,0 +1,141 @@
+{
+    "blue": [
+        {
+            "step": "overscan_sub",
+            "run": true,
+            "suffix": "00",
+            "args": {}
+        },
+        {
+            "step": "bpm_repair",
+            "run": true,
+            "suffix": "01",
+            "args": {}
+        },
+        {
+            "step": "superbias",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "method": "row_med",
+                "plot": false,
+                "verbose": false
+            }
+        },
+        {
+            "step": "bias_sub",
+            "run": true,
+            "suffix": "02",
+            "args": {
+                "method": "subtract",
+                "plot": false,
+                "verbose": false
+            }
+        },
+        {
+            "step": "superflat",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "source": "dome"
+            }
+        },
+        {
+            "step": "superflat",
+            "run": false,
+            "suffix": null,
+            "args": {
+                "source": "twi",
+                "scale": "median_nonzero"
+            }
+        },
+        {
+            "step": "slitlet_profile",
+            "run": true,
+            "suffix": null,
+            "args": {}
+        },
+        {
+            "step": "flat_cleanup",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "type": [
+                    "dome"
+                ],
+                "verbose": true,
+                "plot": false,
+                "offsets": [
+                    0.4,
+                    0.4
+                ],
+                "radius": 10.0,
+                "nsig_lim": 3.0
+            }
+        },
+        {
+            "step": "superflat_mef",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "source": "dome"
+            }
+        },
+        {
+            "step": "superflat_mef",
+            "run": false,
+            "suffix": null,
+            "args": {
+                "source": "twi"
+            }
+        },
+        {
+            "step": "slitlet_mef",
+            "run": true,
+            "suffix": "03",
+            "args": {
+                "ns": false
+            }
+        },
+        {
+            "step": "wave_soln",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "verbose": true,
+                "method": "optical",
+                "shift_method": "xcorr_all",
+                "find_method": "mpfit",
+                "doalphapfit": true,
+                "doplot": false,
+                "dlam_cut_start": 5.0,
+                "multithread": false
+            }
+        },
+        {
+            "step": "wire_soln",
+            "run": true,
+            "suffix": null,
+            "args": {}
+        },
+        {
+            "step": "flat_response",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "mode": "all"
+            }
+        },
+        {
+            "step": "cosmic_rays",
+            "run": true,
+            "suffix": "04",
+            "args": {
+                "ns": false,
+                "multithread": false,
+                "max_processes": -1
+            }
+        }
+    ]
+
+}

--- a/reduction_scripts/pipeline_params/just-calib/blue/params_class_B7000.json
+++ b/reduction_scripts/pipeline_params/just-calib/blue/params_class_B7000.json
@@ -1,0 +1,141 @@
+{
+    "blue": [
+        {
+            "step": "overscan_sub",
+            "run": true,
+            "suffix": "00",
+            "args": {}
+        },
+        {
+            "step": "bpm_repair",
+            "run": true,
+            "suffix": "01",
+            "args": {}
+        },
+        {
+            "step": "superbias",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "method": "row_med",
+                "plot": false,
+                "verbose": false
+            }
+        },
+        {
+            "step": "bias_sub",
+            "run": true,
+            "suffix": "02",
+            "args": {
+                "method": "subtract",
+                "plot": false,
+                "verbose": false
+            }
+        },
+        {
+            "step": "superflat",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "source": "dome"
+            }
+        },
+        {
+            "step": "superflat",
+            "run": false,
+            "suffix": null,
+            "args": {
+                "source": "twi",
+                "scale": "median_nonzero"
+            }
+        },
+        {
+            "step": "slitlet_profile",
+            "run": true,
+            "suffix": null,
+            "args": {}
+        },
+        {
+            "step": "flat_cleanup",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "type": [
+                    "dome"
+                ],
+                "verbose": true,
+                "plot": false,
+                "offsets": [
+                    0.4,
+                    0.4
+                ],
+                "radius": 10.0,
+                "nsig_lim": 3.0
+            }
+        },
+        {
+            "step": "superflat_mef",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "source": "dome"
+            }
+        },
+        {
+            "step": "superflat_mef",
+            "run": false,
+            "suffix": null,
+            "args": {
+                "source": "twi"
+            }
+        },
+        {
+            "step": "slitlet_mef",
+            "run": true,
+            "suffix": "03",
+            "args": {
+                "ns": false
+            }
+        },
+        {
+            "step": "wave_soln",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "verbose": true,
+                "method": "optical",
+                "shift_method": "xcorr_all",
+                "find_method": "mpfit",
+                "doalphapfit": true,
+                "doplot": false,
+                "dlam_cut_start": 5.0,
+                "multithread": false
+            }
+        },
+        {
+            "step": "wire_soln",
+            "run": true,
+            "suffix": null,
+            "args": {}
+        },
+        {
+            "step": "flat_response",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "mode": "dome"
+            }
+        },
+        {
+            "step": "cosmic_rays",
+            "run": true,
+            "suffix": "04",
+            "args": {
+                "ns": false,
+                "multithread": false,
+                "max_processes": -1
+            }
+        }
+    ]
+
+}

--- a/reduction_scripts/pipeline_params/just-calib/blue/params_class_U7000.json
+++ b/reduction_scripts/pipeline_params/just-calib/blue/params_class_U7000.json
@@ -1,0 +1,141 @@
+{
+    "blue": [
+        {
+            "step": "overscan_sub",
+            "run": true,
+            "suffix": "00",
+            "args": {}
+        },
+        {
+            "step": "bpm_repair",
+            "run": true,
+            "suffix": "01",
+            "args": {}
+        },
+        {
+            "step": "superbias",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "method": "row_med",
+                "plot": false,
+                "verbose": false
+            }
+        },
+        {
+            "step": "bias_sub",
+            "run": true,
+            "suffix": "02",
+            "args": {
+                "method": "subtract",
+                "plot": false,
+                "verbose": false
+            }
+        },
+        {
+            "step": "superflat",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "source": "dome"
+            }
+        },
+        {
+            "step": "superflat",
+            "run": false,
+            "suffix": null,
+            "args": {
+                "source": "twi",
+                "scale": "median_nonzero"
+            }
+        },
+        {
+            "step": "slitlet_profile",
+            "run": true,
+            "suffix": null,
+            "args": {}
+        },
+        {
+            "step": "flat_cleanup",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "type": [
+                    "dome"
+                ],
+                "verbose": true,
+                "plot": false,
+                "offsets": [
+                    0.4,
+                    0.4
+                ],
+                "radius": 10.0,
+                "nsig_lim": 3.0
+            }
+        },
+        {
+            "step": "superflat_mef",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "source": "dome"
+            }
+        },
+        {
+            "step": "superflat_mef",
+            "run": false,
+            "suffix": null,
+            "args": {
+                "source": "twi"
+            }
+        },
+        {
+            "step": "slitlet_mef",
+            "run": true,
+            "suffix": "03",
+            "args": {
+                "ns": false
+            }
+        },
+        {
+            "step": "wave_soln",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "verbose": true,
+                "method": "optical",
+                "shift_method": "xcorr_all",
+                "find_method": "mpfit",
+                "doalphapfit": true,
+                "doplot": false,
+                "dlam_cut_start": 5.0,
+                "multithread": false
+            }
+        },
+        {
+            "step": "wire_soln",
+            "run": true,
+            "suffix": null,
+            "args": {}
+        },
+        {
+            "step": "flat_response",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "mode": "all"
+            }
+        },
+        {
+            "step": "cosmic_rays",
+            "run": true,
+            "suffix": "04",
+            "args": {
+                "ns": false,
+                "multithread": false,
+                "max_processes": -1
+            }
+        }
+    ]
+
+}

--- a/reduction_scripts/pipeline_params/just-calib/blue/params_ns_B3000.json
+++ b/reduction_scripts/pipeline_params/just-calib/blue/params_ns_B3000.json
@@ -1,0 +1,140 @@
+{
+    "blue": [
+        {
+            "step": "overscan_sub",
+            "run": true,
+            "suffix": "00",
+            "args": {}
+        },
+        {
+            "step": "bpm_repair",
+            "run": true,
+            "suffix": "01",
+            "args": {}
+        },
+        {
+            "step": "superbias",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "method": "row_med",
+                "plot": false,
+                "verbose": false
+            }
+        },
+        {
+            "step": "bias_sub",
+            "run": true,
+            "suffix": "02",
+            "args": {
+                "method": "subtract",
+                "plot": false,
+                "verbose": false
+            }
+        },
+        {
+            "step": "superflat",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "source": "dome"
+            }
+        },
+        {
+            "step": "superflat",
+            "run": false,
+            "suffix": null,
+            "args": {
+                "source": "twi",
+                "scale": "median_nonzero"
+            }
+        },
+        {
+            "step": "slitlet_profile",
+            "run": true,
+            "suffix": null,
+            "args": {}
+        },
+        {
+            "step": "flat_cleanup",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "type": [
+                    "dome"
+                ],
+                "verbose": true,
+                "plot": false,
+                "offsets": [
+                    0.4,
+                    0.4
+                ],
+                "radius": 10.0,
+                "nsig_lim": 3.0
+            }
+        },
+        {
+            "step": "superflat_mef",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "source": "dome"
+            }
+        },
+        {
+            "step": "superflat_mef",
+            "run": false,
+            "suffix": null,
+            "args": {
+                "source": "twi"
+            }
+        },
+        {
+            "step": "slitlet_mef",
+            "run": true,
+            "suffix": "03",
+            "args": {
+                "ns": true
+            }
+        },
+        {
+            "step": "wave_soln",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "verbose": true,
+                "method": "optical",
+                "shift_method": "xcorr_all",
+                "find_method": "mpfit",
+                "doalphapfit": true,
+                "doplot": false,
+                "dlam_cut_start": 5.0,
+                "multithread": false
+            }
+        },
+        {
+            "step": "wire_soln",
+            "run": true,
+            "suffix": null,
+            "args": {}
+        },
+        {
+            "step": "flat_response",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "mode": "all"
+            }
+        },
+        {
+            "step": "cosmic_rays",
+            "run": true,
+            "suffix": "04",
+            "args": {
+                "ns": true,
+                "multithread": false,
+                "max_processes": -1
+            }
+        }
+    ]
+}

--- a/reduction_scripts/pipeline_params/just-calib/blue/params_ns_B7000.json
+++ b/reduction_scripts/pipeline_params/just-calib/blue/params_ns_B7000.json
@@ -1,0 +1,140 @@
+{
+    "blue": [
+        {
+            "step": "overscan_sub",
+            "run": true,
+            "suffix": "00",
+            "args": {}
+        },
+        {
+            "step": "bpm_repair",
+            "run": true,
+            "suffix": "01",
+            "args": {}
+        },
+        {
+            "step": "superbias",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "method": "row_med",
+                "plot": false,
+                "verbose": false
+            }
+        },
+        {
+            "step": "bias_sub",
+            "run": true,
+            "suffix": "02",
+            "args": {
+                "method": "subtract",
+                "plot": false,
+                "verbose": false
+            }
+        },
+        {
+            "step": "superflat",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "source": "dome"
+            }
+        },
+        {
+            "step": "superflat",
+            "run": false,
+            "suffix": null,
+            "args": {
+                "source": "twi",
+                "scale": "median_nonzero"
+            }
+        },
+        {
+            "step": "slitlet_profile",
+            "run": true,
+            "suffix": null,
+            "args": {}
+        },
+        {
+            "step": "flat_cleanup",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "type": [
+                    "dome"
+                ],
+                "verbose": true,
+                "plot": false,
+                "offsets": [
+                    0.4,
+                    0.4
+                ],
+                "radius": 10.0,
+                "nsig_lim": 3.0
+            }
+        },
+        {
+            "step": "superflat_mef",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "source": "dome"
+            }
+        },
+        {
+            "step": "superflat_mef",
+            "run": false,
+            "suffix": null,
+            "args": {
+                "source": "twi"
+            }
+        },
+        {
+            "step": "slitlet_mef",
+            "run": true,
+            "suffix": "03",
+            "args": {
+                "ns": true
+            }
+        },
+        {
+            "step": "wave_soln",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "verbose": true,
+                "method": "optical",
+                "shift_method": "xcorr_all",
+                "find_method": "mpfit",
+                "doalphapfit": true,
+                "doplot": false,
+                "dlam_cut_start": 5.0,
+                "multithread": false
+            }
+        },
+        {
+            "step": "wire_soln",
+            "run": true,
+            "suffix": null,
+            "args": {}
+        },
+        {
+            "step": "flat_response",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "mode": "all"
+            }
+        },
+        {
+            "step": "cosmic_rays",
+            "run": true,
+            "suffix": "04",
+            "args": {
+                "ns": true,
+                "multithread": false,
+                "max_processes": -1
+            }
+        }
+    ]
+}

--- a/reduction_scripts/pipeline_params/just-calib/blue/params_ns_U7000.json
+++ b/reduction_scripts/pipeline_params/just-calib/blue/params_ns_U7000.json
@@ -1,0 +1,140 @@
+{
+    "blue": [
+        {
+            "step": "overscan_sub",
+            "run": true,
+            "suffix": "00",
+            "args": {}
+        },
+        {
+            "step": "bpm_repair",
+            "run": true,
+            "suffix": "01",
+            "args": {}
+        },
+        {
+            "step": "superbias",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "method": "row_med",
+                "plot": false,
+                "verbose": false
+            }
+        },
+        {
+            "step": "bias_sub",
+            "run": true,
+            "suffix": "02",
+            "args": {
+                "method": "subtract",
+                "plot": false,
+                "verbose": false
+            }
+        },
+        {
+            "step": "superflat",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "source": "dome"
+            }
+        },
+        {
+            "step": "superflat",
+            "run": false,
+            "suffix": null,
+            "args": {
+                "source": "twi",
+                "scale": "median_nonzero"
+            }
+        },
+        {
+            "step": "slitlet_profile",
+            "run": true,
+            "suffix": null,
+            "args": {}
+        },
+        {
+            "step": "flat_cleanup",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "type": [
+                    "dome"
+                ],
+                "verbose": true,
+                "plot": false,
+                "offsets": [
+                    0.4,
+                    0.4
+                ],
+                "radius": 10.0,
+                "nsig_lim": 3.0
+            }
+        },
+        {
+            "step": "superflat_mef",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "source": "dome"
+            }
+        },
+        {
+            "step": "superflat_mef",
+            "run": false,
+            "suffix": null,
+            "args": {
+                "source": "twi"
+            }
+        },
+        {
+            "step": "slitlet_mef",
+            "run": true,
+            "suffix": "03",
+            "args": {
+                "ns": true
+            }
+        },
+        {
+            "step": "wave_soln",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "verbose": true,
+                "method": "optical",
+                "shift_method": "xcorr_all",
+                "find_method": "mpfit",
+                "doalphapfit": true,
+                "doplot": false,
+                "dlam_cut_start": 5.0,
+                "multithread": false
+            }
+        },
+        {
+            "step": "wire_soln",
+            "run": true,
+            "suffix": null,
+            "args": {}
+        },
+        {
+            "step": "flat_response",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "mode": "all"
+            }
+        },
+        {
+            "step": "cosmic_rays",
+            "run": true,
+            "suffix": "04",
+            "args": {
+                "ns": true,
+                "multithread": false,
+                "max_processes": -1
+            }
+        }
+    ]
+}

--- a/reduction_scripts/pipeline_params/just-calib/red/params_class_I7000.json
+++ b/reduction_scripts/pipeline_params/just-calib/red/params_class_I7000.json
@@ -1,0 +1,131 @@
+{
+    "red": [
+        {
+            "step": "overscan_sub",
+            "run": true,
+            "suffix": "00",
+            "args": {}
+        },
+        {
+            "step": "bpm_repair",
+            "run": true,
+            "suffix": "01",
+            "args": {}
+        },
+        {
+            "step": "superbias",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "method": "row_med",
+                "plot": false,
+                "verbose": false
+            }
+        },
+        {
+            "step": "bias_sub",
+            "run": true,
+            "suffix": "02",
+            "args": {
+                "method": "subtract",
+                "plot": false,
+                "verbose": false
+            }
+        },
+        {
+            "step": "superflat",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "source": "dome"
+            }
+        },
+        {
+            "step": "superflat",
+            "run": false,
+            "suffix": null,
+            "args": {
+                "source": "twi",
+                "scale": "median_nonzero"
+            }
+        },
+        {
+            "step": "slitlet_profile",
+            "run": true,
+            "suffix": null,
+            "args": {}
+        },
+        {
+            "step": "flat_cleanup",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "type": [
+                    "dome"
+                ],
+                "verbose": true,
+                "plot": false,
+                "buffer": 4,
+                "offsets": [
+                    0.4,
+                    0.4
+                ],
+                "radius": 10.0,
+                "nsig_lim": 3.0
+            }
+        },
+        {
+            "step": "superflat_mef",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "source": "dome"
+            }
+        },
+        {
+            "step": "superflat_mef",
+            "run": false,
+            "suffix": null,
+            "args": {
+                "source": "twi"
+            }
+        },
+        {
+            "step": "slitlet_mef",
+            "run": true,
+            "suffix": "03",
+            "args": {
+                "ns": false
+            }
+        },
+        {
+            "step": "wave_soln",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "verbose": true,
+                "method": "optical",
+                "doalphapfit": true,
+                "doplot": false,
+                "shift_method": "xcorr_all",
+                "find_method": "mpfit",
+                "dlam_cut_start": 5.0,
+                "multithread": false
+            }
+        },
+        {
+            "step": "wire_soln",
+            "run": true,
+            "suffix": null,
+            "args": {}
+        },
+        {
+            "step": "flat_response",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "mode": "dome"
+            }
+        }
+    ]
+}

--- a/reduction_scripts/pipeline_params/just-calib/red/params_class_R3000.json
+++ b/reduction_scripts/pipeline_params/just-calib/red/params_class_R3000.json
@@ -1,0 +1,141 @@
+{
+    "red": [
+        {
+            "step": "overscan_sub",
+            "run": true,
+            "suffix": "00",
+            "args": {}
+        },
+        {
+            "step": "bpm_repair",
+            "run": true,
+            "suffix": "01",
+            "args": {}
+        },
+        {
+            "step": "superbias",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "method": "row_med",
+                "plot": false,
+                "verbose": false
+            }
+        },
+        {
+            "step": "bias_sub",
+            "run": true,
+            "suffix": "02",
+            "args": {
+                "method": "subtract",
+                "plot": false,
+                "verbose": false
+            }
+        },
+        {
+            "step": "superflat",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "source": "dome"
+            }
+        },
+        {
+            "step": "superflat",
+            "run": false,
+            "suffix": null,
+            "args": {
+                "source": "twi",
+                "scale": "median_nonzero"
+            }
+        },
+        {
+            "step": "slitlet_profile",
+            "run": true,
+            "suffix": null,
+            "args": {}
+        },
+        {
+            "step": "flat_cleanup",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "type": [
+                    "dome"
+                ],
+                "verbose": true,
+                "plot": false,
+                "buffer": 4,
+                "offsets": [
+                    0.4,
+                    0.4
+                ],
+                "radius": 10.0,
+                "nsig_lim": 3.0
+            }
+        },
+        {
+            "step": "superflat_mef",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "source": "dome"
+            }
+        },
+        {
+            "step": "superflat_mef",
+            "run": false,
+            "suffix": null,
+            "args": {
+                "source": "twi"
+            }
+        },
+        {
+            "step": "slitlet_mef",
+            "run": true,
+            "suffix": "03",
+            "args": {
+                "ns": false
+            }
+        },
+        {
+            "step": "wave_soln",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "verbose": true,
+                "method": "optical",
+                "doalphapfit": true,
+                "doplot": false,
+                "shift_method": "xcorr_all",
+                "find_method": "mpfit",
+                "dlam_cut_start": 5.0,
+                "multithread": false
+            }
+        },
+        {
+            "step": "wire_soln",
+            "run": true,
+            "suffix": null,
+            "args": {}
+        },
+        {
+            "step": "flat_response",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "mode": "dome"
+            }
+        },
+        {
+            "step": "cosmic_rays",
+            "run": true,
+            "suffix": "04",
+            "args": {
+                "ns": false,
+                "multithread": false,
+                "max_processes": -1
+            }
+        }
+    ]
+}

--- a/reduction_scripts/pipeline_params/just-calib/red/params_class_R7000.json
+++ b/reduction_scripts/pipeline_params/just-calib/red/params_class_R7000.json
@@ -1,0 +1,141 @@
+{
+    "red": [
+        {
+            "step": "overscan_sub",
+            "run": true,
+            "suffix": "00",
+            "args": {}
+        },
+        {
+            "step": "bpm_repair",
+            "run": true,
+            "suffix": "01",
+            "args": {}
+        },
+        {
+            "step": "superbias",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "method": "row_med",
+                "plot": false,
+                "verbose": false
+            }
+        },
+        {
+            "step": "bias_sub",
+            "run": true,
+            "suffix": "02",
+            "args": {
+                "method": "subtract",
+                "plot": false,
+                "verbose": false
+            }
+        },
+        {
+            "step": "superflat",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "source": "dome"
+            }
+        },
+        {
+            "step": "superflat",
+            "run": false,
+            "suffix": null,
+            "args": {
+                "source": "twi",
+                "scale": "median_nonzero"
+            }
+        },
+        {
+            "step": "slitlet_profile",
+            "run": true,
+            "suffix": null,
+            "args": {}
+        },
+        {
+            "step": "flat_cleanup",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "type": [
+                    "dome"
+                ],
+                "verbose": true,
+                "plot": false,
+                "buffer": 4,
+                "offsets": [
+                    0.4,
+                    0.4
+                ],
+                "radius": 10.0,
+                "nsig_lim": 3.0
+            }
+        },
+        {
+            "step": "superflat_mef",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "source": "dome"
+            }
+        },
+        {
+            "step": "superflat_mef",
+            "run": false,
+            "suffix": null,
+            "args": {
+                "source": "twi"
+            }
+        },
+        {
+            "step": "slitlet_mef",
+            "run": true,
+            "suffix": "03",
+            "args": {
+                "ns": false
+            }
+        },
+        {
+            "step": "wave_soln",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "verbose": true,
+                "method": "optical",
+                "doalphapfit": true,
+                "doplot": false,
+                "shift_method": "xcorr_all",
+                "find_method": "mpfit",
+                "dlam_cut_start": 5.0,
+                "multithread": false
+            }
+        },
+        {
+            "step": "wire_soln",
+            "run": true,
+            "suffix": null,
+            "args": {}
+        },
+        {
+            "step": "flat_response",    
+            "run": true,
+            "suffix": null,
+            "args": {
+                "mode": "dome"
+            }
+        },
+        {
+            "step": "cosmic_rays",
+            "run": true,
+            "suffix": "04",
+            "args": {
+                "ns": false,
+                "multithread": false,
+                "max_processes": -1
+            }
+        }
+    ]
+}

--- a/reduction_scripts/pipeline_params/just-calib/red/params_ns_I7000.json
+++ b/reduction_scripts/pipeline_params/just-calib/red/params_ns_I7000.json
@@ -1,0 +1,141 @@
+{
+    "red": [
+        {
+            "step": "overscan_sub",
+            "run": true,
+            "suffix": "00",
+            "args": {}
+        },
+        {
+            "step": "bpm_repair",
+            "run": true,
+            "suffix": "01",
+            "args": {}
+        },
+        {
+            "step": "superbias",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "method": "row_med",
+                "plot": false,
+                "verbose": false
+            }
+        },
+        {
+            "step": "bias_sub",
+            "run": true,
+            "suffix": "02",
+            "args": {
+                "method": "subtract",
+                "plot": false,
+                "verbose": false
+            }
+        },
+        {
+            "step": "superflat",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "source": "dome"
+            }
+        },
+        {
+            "step": "superflat",
+            "run": false,
+            "suffix": null,
+            "args": {
+                "source": "twi",
+                "scale": "median_nonzero"
+            }
+        },
+        {
+            "step": "slitlet_profile",
+            "run": true,
+            "suffix": null,
+            "args": {}
+        },
+        {
+            "step": "flat_cleanup",
+            "run": false,
+            "suffix": null,
+            "args": {
+                "type": [
+                    "dome"
+                ],
+                "verbose": true,
+                "plot": false,
+                "buffer": 4,
+                "offsets": [
+                    0.4,
+                    0.4
+                ],
+                "radius": 10.0,
+                "nsig_lim": 3.0
+            }
+        },
+        {
+            "step": "superflat_mef",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "source": "dome"
+            }
+        },
+        {
+            "step": "superflat_mef",
+            "run": false,
+            "suffix": null,
+            "args": {
+                "source": "twi"
+            }
+        },
+        {
+            "step": "slitlet_mef",
+            "run": true,
+            "suffix": "03",
+            "args": {
+                "ns": true
+            }
+        },
+        {
+            "step": "wave_soln",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "verbose": true,
+                "method": "optical",
+                "doalphapfit": true,
+                "doplot": false,
+                "shift_method": "xcorr_all",
+                "find_method": "mpfit",
+                "dlam_cut_start": 5.0,
+                "multithread": false
+            }
+        },
+        {
+            "step": "wire_soln",
+            "run": true,
+            "suffix": null,
+            "args": {}
+        },
+        {
+            "step": "flat_response",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "mode": "dome"
+            }
+        },
+        {
+            "step": "cosmic_rays",
+            "run": true,
+            "suffix": "04",
+            "args": {
+                "ns": true,
+                "multithread": false,
+                "max_processes": -1
+            }
+        }
+    ]
+}

--- a/reduction_scripts/pipeline_params/just-calib/red/params_ns_R3000.json
+++ b/reduction_scripts/pipeline_params/just-calib/red/params_ns_R3000.json
@@ -1,0 +1,141 @@
+{
+    "red": [
+        {
+            "step": "overscan_sub",
+            "run": true,
+            "suffix": "00",
+            "args": {}
+        },
+        {
+            "step": "bpm_repair",
+            "run": true,
+            "suffix": "01",
+            "args": {}
+        },
+        {
+            "step": "superbias",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "method": "row_med",
+                "plot": false,
+                "verbose": false
+            }
+        },
+        {
+            "step": "bias_sub",
+            "run": true,
+            "suffix": "02",
+            "args": {
+                "method": "subtract",
+                "plot": false,
+                "verbose": false
+            }
+        },
+        {
+            "step": "superflat",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "source": "dome"
+            }
+        },
+        {
+            "step": "superflat",
+            "run": false,
+            "suffix": null,
+            "args": {
+                "source": "twi",
+                "scale": "median_nonzero"
+            }
+        },
+        {
+            "step": "slitlet_profile",
+            "run": true,
+            "suffix": null,
+            "args": {}
+        },
+        {
+            "step": "flat_cleanup",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "type": [
+                    "dome"
+                ],
+                "verbose": true,
+                "plot": false,
+                "buffer": 4,
+                "offsets": [
+                    0.4,
+                    0.4
+                ],
+                "radius": 10.0,
+                "nsig_lim": 3.0
+            }
+        },
+        {
+            "step": "superflat_mef",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "source": "dome"
+            }
+        },
+        {
+            "step": "superflat_mef",
+            "run": false,
+            "suffix": null,
+            "args": {
+                "source": "twi"
+            }
+        },
+        {
+            "step": "slitlet_mef",
+            "run": true,
+            "suffix": "03",
+            "args": {
+                "ns": true
+            }
+        },
+        {
+            "step": "wave_soln",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "verbose": true,
+                "method": "optical",
+                "doalphapfit": true,
+                "doplot": false,
+                "shift_method": "xcorr_all",
+                "find_method": "mpfit",
+                "dlam_cut_start": 5.0,
+                "multithread": false
+            }
+        },
+        {
+            "step": "wire_soln",
+            "run": true,
+            "suffix": null,
+            "args": {}
+        },
+        {
+            "step": "flat_response",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "mode": "dome"
+            }
+        },
+        {
+            "step": "cosmic_rays",
+            "run": true,
+            "suffix": "04",
+            "args": {
+                "ns": true,
+                "multithread": false,
+                "max_processes": -1
+            }
+        }
+    ]
+}

--- a/reduction_scripts/pipeline_params/just-calib/red/params_ns_R7000.json
+++ b/reduction_scripts/pipeline_params/just-calib/red/params_ns_R7000.json
@@ -1,0 +1,141 @@
+{
+    "red": [
+        {
+            "step": "overscan_sub",
+            "run": true,
+            "suffix": "00",
+            "args": {}
+        },
+        {
+            "step": "bpm_repair",
+            "run": true,
+            "suffix": "01",
+            "args": {}
+        },
+        {
+            "step": "superbias",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "method": "row_med",
+                "plot": false,
+                "verbose": false
+            }
+        },
+        {
+            "step": "bias_sub",
+            "run": true,
+            "suffix": "02",
+            "args": {
+                "method": "subtract",
+                "plot": false,
+                "verbose": false
+            }
+        },
+        {
+            "step": "superflat",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "source": "dome"
+            }
+        },
+        {
+            "step": "superflat",
+            "run": false,
+            "suffix": null,
+            "args": {
+                "source": "twi",
+                "scale": "median_nonzero"
+            }
+        },
+        {
+            "step": "slitlet_profile",
+            "run": true,
+            "suffix": null,
+            "args": {}
+        },
+        {
+            "step": "flat_cleanup",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "type": [
+                    "dome"
+                ],
+                "verbose": true,
+                "plot": false,
+                "buffer": 4,
+                "offsets": [
+                    0.4,
+                    0.4
+                ],
+                "radius": 10.0,
+                "nsig_lim": 3.0
+            }
+        },
+        {
+            "step": "superflat_mef",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "source": "dome"
+            }
+        },
+        {
+            "step": "superflat_mef",
+            "run": false,
+            "suffix": null,
+            "args": {
+                "source": "twi"
+            }
+        },
+        {
+            "step": "slitlet_mef",
+            "run": true,
+            "suffix": "03",
+            "args": {
+                "ns": true
+            }
+        },
+        {
+            "step": "wave_soln",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "verbose": true,
+                "method": "optical",
+                "doalphapfit": true,
+                "doplot": false,
+                "shift_method": "xcorr_all",
+                "find_method": "mpfit",
+                "dlam_cut_start": 5.0,
+                "multithread": false
+            }
+        },
+        {
+            "step": "wire_soln",
+            "run": true,
+            "suffix": null,
+            "args": {}
+        },
+        {
+            "step": "flat_response",
+            "run": true,
+            "suffix": null,
+            "args": {
+                "mode": "dome"
+            }
+        },
+        {
+            "step": "cosmic_rays",
+            "run": false,
+            "suffix": "04",
+            "args": {
+                "ns": true,
+                "multithread": false,
+                "max_processes": -1
+            }
+        }
+    ]
+}

--- a/reduction_scripts/reduce_data.py
+++ b/reduction_scripts/reduce_data.py
@@ -66,9 +66,8 @@ def main():
             metadata["bias"]
             + metadata["arc"]
             + metadata["wire"]
-            +
-            # metadata['dark']+
-            metadata["domeflat"]
+            # + metadata['dark']
+            + metadata["domeflat"]
             + metadata["twiflat"]
         )
         for fn in base_fn_list:
@@ -188,13 +187,15 @@ def main():
     # Generate super-bias
     # ------------------------------------------------------
     def run_superbias(metadata, prev_suffix, curr_suffix, method="row_med", **args):
-        bias_list = [
-            os.path.join(out_dir, "%s.p%s.fits" % (x, prev_suffix))
-            for x in metadata["bias"]
-        ]
-        print("Calculating Global Superbias")
-        pywifes.imcombine(bias_list, superbias_fn, data_hdu=my_data_hdu)
-        # decide what bias model you will actually subtract - could be just data
+        # Super-bias is not generated if master calibrations are used.
+        if from_master is None:
+            bias_list = [
+                os.path.join(out_dir, "%s.p%s.fits" % (x, prev_suffix))
+                for x in metadata["bias"]
+            ]
+            print("Calculating Global Superbias")
+            pywifes.imcombine(bias_list, superbias_fn, data_hdu=my_data_hdu)
+            # decide what bias model you will actually subtract - could be just data
         if method == "fit" or method == "row_med":
             # Fit a smart surface to the bias or take the median
             # A bit experimental so far ... but you know what you are doing, right ?
@@ -207,6 +208,7 @@ def main():
             )
         else:
             pywifes.imcopy(superbias_fn, superbias_fit_fn)
+
         # generate local superbiases for any science frames
         sci_obs_list = get_sci_obs_list(metadata)
         std_obs_list = get_std_obs_list(metadata)
@@ -272,6 +274,7 @@ def main():
             else:
                 bias_fit_fn = superbias_fit_fn
                 bias_type = "global"
+
             # subtract it!
             print("Subtracting %s superbias for %s" % (bias_type, in_fn.split("/")[-1]))
             if method == "copy":
@@ -286,24 +289,26 @@ def main():
     def run_superflat(
         metadata, prev_suffix, curr_suffix, source, scale=None, method="median"
     ):
-        if source == "dome":
-            flat_list = [
-                os.path.join(out_dir, "%s.p%s.fits" % (x, prev_suffix))
-                for x in metadata["domeflat"]
-            ]
-            out_fn = super_dflat_raw
-        elif source == "twi":
-            flat_list = [
-                os.path.join(out_dir, "%s.p%s.fits" % (x, prev_suffix))
-                for x in metadata["twiflat"]
-            ]
-            out_fn = super_tflat_raw
-        else:
-            raise ValueError("Flatfield type not recognized")
-        print("Generating co-add %sflat" % source)
-        pywifes.imcombine(
-            flat_list, out_fn, data_hdu=my_data_hdu, scale=scale, method=method
-        )
+        # Super-flat is not generated if master calibrations are used.
+        if from_master is None:
+            if source == "dome":
+                flat_list = [
+                    os.path.join(out_dir, "%s.p%s.fits" % (x, prev_suffix))
+                    for x in metadata["domeflat"]
+                ]
+                out_fn = super_dflat_raw
+            elif source == "twi":
+                flat_list = [
+                    os.path.join(out_dir, "%s.p%s.fits" % (x, prev_suffix))
+                    for x in metadata["twiflat"]
+                ]
+                out_fn = super_tflat_raw
+            else:
+                raise ValueError("Flatfield type not recognized")
+            print("Generating co-add %sflat" % source)
+            pywifes.imcombine(
+                flat_list, out_fn, data_hdu=my_data_hdu, scale=scale, method=method
+            )
         return
 
     # ------------------------------------------------------
@@ -317,77 +322,84 @@ def main():
         offsets=[0.0, 0.0],
         **args,
     ):
-        # check the slitlet definition file
-        if os.path.isfile(slitlet_def_fn):
-            slitlet_fn = slitlet_def_fn
-        else:
-            slitlet_fn = None
-        if "dome" in type:
-            print("Correcting master domeflat", super_dflat_fn.split("/")[-1])
-            pywifes.interslice_cleanup(
-                super_dflat_raw,
-                super_dflat_fn,
-                slitlet_fn,
-                offset=offsets[type.index("dome")],
-                method="2D",
-                **args,
-            )
-        if "twi" in type:
-            print("Correcting master twilight flat", super_tflat_fn.split("/")[-1])
-            pywifes.interslice_cleanup(
-                super_tflat_raw,
-                super_tflat_fn,
-                slitlet_fn,
-                offset=offsets[type.index("twi")],
-                method="2D",
-                **args,
-            )
+        
+        # Ony run cleanup if no master calibrations are used.
+        if from_master is None:
+            # check the slitlet definition file
+            if os.path.isfile(slitlet_def_fn):
+                slitlet_fn = slitlet_def_fn
+            else:
+                slitlet_fn = None
+            if "dome" in type:
+                print("Correcting master domeflat", super_dflat_fn.split("/")[-1])
+                pywifes.interslice_cleanup(
+                    super_dflat_raw,
+                    super_dflat_fn,
+                    slitlet_fn,
+                    offset=offsets[type.index("dome")],
+                    method="2D",
+                    **args,
+                )
+            if "twi" in type:
+                print("Correcting master twilight flat", super_tflat_fn.split("/")[-1])
+                pywifes.interslice_cleanup(
+                    super_tflat_raw,
+                    super_tflat_fn,
+                    slitlet_fn,
+                    offset=offsets[type.index("twi")],
+                    method="2D",
+                    **args,
+                )
         return
 
     # ------------------------------------------------------
     # Fit slitlet profiles
     # ------------------------------------------------------
     def run_slitlet_profile(metadata, prev_suffix, curr_suffix, **args):
-        if os.path.isfile(super_dflat_fn):
-            flatfield_fn = super_dflat_fn
-        else:
-            flatfield_fn = super_dflat_raw
-        output_fn = slitlet_def_fn
-        pywifes.derive_slitlet_profiles(
-            flatfield_fn, output_fn, data_hdu=my_data_hdu, **args
-        )
+        # Only run if no master calibrations are used.
+        if from_master is None:
+            if os.path.isfile(super_dflat_fn):
+                flatfield_fn = super_dflat_fn
+            else:
+                flatfield_fn = super_dflat_raw
+            output_fn = slitlet_def_fn
+            pywifes.derive_slitlet_profiles(
+                flatfield_fn, output_fn, data_hdu=my_data_hdu, **args
+            )
         return
 
     # ------------------------------------------------------
     # Create MEF files
     # ------------------------------------------------------
     def run_superflat_mef(metadata, prev_suffix, curr_suffix, source):
-        if source == "dome":
-            if os.path.isfile(super_dflat_fn):
-                in_fn = super_dflat_fn
-            else:
-                in_fn = super_dflat_raw
-            out_fn = super_dflat_mef
+        # Only run if no master calibrations are used.
+        if from_master is None:
+            if source == "dome":
+                if os.path.isfile(super_dflat_fn):
+                    in_fn = super_dflat_fn
+                else:
+                    in_fn = super_dflat_raw
+                out_fn = super_dflat_mef
 
-        elif source == "twi":
-            if os.path.isfile(super_tflat_fn):
-                in_fn = super_tflat_fn
-            else:
-                in_fn = super_tflat_raw
-            out_fn = super_tflat_mef
+            elif source == "twi":
+                if os.path.isfile(super_tflat_fn):
+                    in_fn = super_tflat_fn
+                else:
+                    in_fn = super_tflat_raw
+                out_fn = super_tflat_mef
 
-        else:
-            raise ValueError("Flatfield type not recognized")
-        # check the slitlet definition file
-        if os.path.isfile(slitlet_def_fn):
-            slitlet_fn = slitlet_def_fn
-        else:
-            slitlet_fn = None
-        # run it!
-        print("Generating MEF %sflat" % source)
-        pywifes.wifes_slitlet_mef(
-            in_fn, out_fn, data_hdu=my_data_hdu, slitlet_def_file=slitlet_fn
-        )
+            else:
+                raise ValueError("Flatfield type not recognized")
+            # check the slitlet definition file
+            if os.path.isfile(slitlet_def_fn):
+                slitlet_fn = slitlet_def_fn
+            else:
+                slitlet_fn = None
+            # run it!
+            print("Generating MEF %sflat" % source)
+            pywifes.wifes_slitlet_mef(
+                in_fn, out_fn, data_hdu=my_data_hdu, slitlet_def_file=slitlet_fn
+            )
         return
 
     def run_slitlet_mef(metadata, prev_suffix, curr_suffix, ns=False):
@@ -427,69 +439,73 @@ def main():
     # Wavelength solution
     # ------------------------------------------------------
     def run_wave_soln(metadata, prev_suffix, curr_suffix, **args):
-        # First, generate the master arc solution, based on generic arcs
-        wsol_in_fn = os.path.join(
-            out_dir, "%s.p%s.fits" % (metadata["arc"][0], prev_suffix)
-        )
-        print("Deriving master wavelength solution from %s" % wsol_in_fn.split("/")[-1])
-        wifes_wsol.derive_wifes_wave_solution(wsol_in_fn, wsol_out_fn, **args)
-        # local wave solutions for science or standards
-        sci_obs_list = get_sci_obs_list(metadata)
-        std_obs_list = get_std_obs_list(metadata)
-        for fn in sci_obs_list + std_obs_list:
-            # Check if the file has a dedicated arc associated with it ...
-            # Only for Science and Std stars for now (sky not required at this stage)
-            # (less critical for the rest anyway ...)
-            # As per Mike I. pull request: if two arcs are present, find a solution
-            # for both to later interpolate between them.
-            # Restrict it to the first two arcs in the list (in case the feature is
-            # being unknowingly used, avoid too much lost time).
-            local_arcs = get_associated_calib(metadata, fn, "arc")
-            if local_arcs:
-                for i in range(np.min([2, np.size(local_arcs)])):
-                    local_arc_fn = os.path.join(
-                        out_dir, "%s.p%s.fits" % (local_arcs[i], prev_suffix)
-                    )
-                    local_wsol_out_fn = os.path.join(
-                        out_dir, "%s.wsol.fits" % (local_arcs[i])
-                    )
-                    if os.path.isfile(local_wsol_out_fn):
-                        continue
-                    print("Deriving local wavelength solution for %s" % local_arcs[i])
-                    wifes_wsol.derive_wifes_wave_solution(
-                        local_arc_fn, local_wsol_out_fn, **args
-                    )
+        # Only run if no master calibrations are used.
+        if from_master is None:
+            # First, generate the master arc solution, based on generic arcs
+            wsol_in_fn = os.path.join(
+                out_dir, "%s.p%s.fits" % (metadata["arc"][0], prev_suffix)
+            )
+            print("Deriving master wavelength solution from %s" % wsol_in_fn.split("/")[-1])
+            wifes_wsol.derive_wifes_wave_solution(wsol_in_fn, wsol_out_fn, **args)
+            # local wave solutions for science or standards
+            sci_obs_list = get_sci_obs_list(metadata)
+            std_obs_list = get_std_obs_list(metadata)
+            for fn in sci_obs_list + std_obs_list:
+                # Check if the file has a dedicated arc associated with it ...
+                # Only for Science and Std stars for now (sky not required at this stage)
+                # (less critical for the rest anyway ...)
+                # As per Mike I. pull request: if two arcs are present, find a solution
+                # for both to later interpolate between them.
+                # Restrict it to the first two arcs in the list (in case the feature is
+                # being unknowingly used, avoid too much lost time).
+                local_arcs = get_associated_calib(metadata, fn, "arc")
+                if local_arcs:
+                    for i in range(np.min([2, np.size(local_arcs)])):
+                        local_arc_fn = os.path.join(
+                            out_dir, "%s.p%s.fits" % (local_arcs[i], prev_suffix)
+                        )
+                        local_wsol_out_fn = os.path.join(
+                            out_dir, "%s.wsol.fits" % (local_arcs[i])
+                        )
+                        if os.path.isfile(local_wsol_out_fn):
+                            continue
+                        print("Deriving local wavelength solution for %s" % local_arcs[i])
+                        wifes_wsol.derive_wifes_wave_solution(
+                            local_arc_fn, local_wsol_out_fn, **args
+                        )
         return
 
     # ------------------------------------------------------
     # Wire solution
     # ------------------------------------------------------
     def run_wire_soln(metadata, prev_suffix, curr_suffix):
-        # Global wire solution
-        wire_in_fn = os.path.join(
-            out_dir, "%s.p%s.fits" % (metadata["wire"][0], prev_suffix)
-        )
-        print("Deriving global wire solution from %s" % wire_in_fn.split("/")[-1])
-        pywifes.derive_wifes_wire_solution(wire_in_fn, wire_out_fn)
-        # Wire solutions for any specific obsevations
-        sci_obs_list = get_sci_obs_list(metadata)
-        std_obs_list = get_std_obs_list(metadata)
-        for fn in sci_obs_list + std_obs_list:
-            # Check if the file has a dedicated wire associated with it ...
-            # Only for Science and Std stars for now (sky not required at this stage)
-            # (less critical for the rest anyway ...)
-            local_wires = get_associated_calib(metadata, fn, "wire")
-            if local_wires:
-                local_wire_fn = os.path.join(
-                    out_dir, "%s.p%s.fits" % (local_wires[0], prev_suffix)
-                )
-                local_wire_out_fn = os.path.join(
-                    out_dir, "%s.wire.fits" % (out_dir, local_wires[0])
-                )
-                if os.path.isfile(local_wire_out_fn):
-                    continue
-                print("Deriving local wire solution for %s" % local_wires[0])
-                pywifes.derive_wifes_wire_solution(local_wire_fn, local_wire_out_fn)
+        # Only run if no master calibrations are used.
+        if from_master is None:
+            # Global wire solution
+            wire_in_fn = os.path.join(
+                out_dir, "%s.p%s.fits" % (metadata["wire"][0], prev_suffix)
+            )
+            print("Deriving global wire solution from %s" % wire_in_fn.split("/")[-1])
+            pywifes.derive_wifes_wire_solution(wire_in_fn, wire_out_fn)
+            # Wire solutions for any specific obsevations
+            sci_obs_list = get_sci_obs_list(metadata)
+            std_obs_list = get_std_obs_list(metadata)
+            for fn in sci_obs_list + std_obs_list:
+                # Check if the file has a dedicated wire associated with it ...
+                # Only for Science and Std stars for now (sky not required at this stage)
+                # (less critical for the rest anyway ...)
+                local_wires = get_associated_calib(metadata, fn, "wire")
+                if local_wires:
+                    local_wire_fn = os.path.join(
+                        out_dir, "%s.p%s.fits" % (local_wires[0], prev_suffix)
+                    )
+                    local_wire_out_fn = os.path.join(
+                        out_dir, "%s.wire.fits" % (out_dir, local_wires[0])
+                    )
+                    if os.path.isfile(local_wire_out_fn):
+                        continue
+                    print("Deriving local wire solution for %s" % local_wires[0])
+                    pywifes.derive_wifes_wire_solution(local_wire_fn, local_wire_out_fn)
         return
 
     # ------------------------------------------------------
@@ -667,18 +683,20 @@ def main():
     # Flatfield: Response
     # ------------------------------------------------------
     def run_flat_response(metadata, prev_suffix, curr_suffix, mode="all"):
-        # now fit the desired style of response function
-        print("Generating flatfield response function")
-        if mode == "all":
-            pywifes.wifes_2dim_response(
-                super_dflat_mef, super_tflat_mef, flat_resp_fn, wsol_fn=wsol_out_fn
-            )
-        elif mode == "dome":
-            pywifes.wifes_response_poly(
-                super_dflat_mef, flat_resp_fn, wsol_fn=wsol_out_fn
-            )
-        else:
-            raise ValueError("Requested response mode not recognized")
+        # Only run if no master calibrations are used.
+        if from_master is None:
+            # now fit the desired style of response function
+            print("Generating flatfield response function")
+            if mode == "all":
+                pywifes.wifes_2dim_response(
+                    super_dflat_mef, super_tflat_mef, flat_resp_fn, wsol_fn=wsol_out_fn
+                )
+            elif mode == "dome":
+                pywifes.wifes_response_poly(
+                    super_dflat_mef, flat_resp_fn, wsol_fn=wsol_out_fn
+                )
+            else:
+                raise ValueError("Requested response mode not recognized")
         return
 
     # ------------------------------------------------------
@@ -947,6 +965,20 @@ def main():
         help="Optional: Path to the configuration JSON file containing parameters for reducing the blue arm.",
     )
 
+    # Option for triggering the reduction from master calibrations
+    parser.add_argument(
+        "--from-master",
+        type=str,
+        help="Optional: Path to the master calibrations directory.",
+    )
+
+    # Option for specifying to skip already completed steps
+    parser.add_argument(
+        "-skip-done",
+        action="store_true",
+        help="Optional: Skip already completed steps.",
+    )
+
     args = parser.parse_args()
 
     # Validate and process the data_dir
@@ -971,6 +1003,10 @@ def main():
         params_path["blue"] = os.path.abspath(args.blue_params)
         print(f"Using blue parameters from: {params_path['blue']}")
 
+    # Reduction from master calibration frames
+    from_master = args.from_master
+
+    
     # Classify all raw data (red and blue arm)
     naxis2_to_process = 0  # TODO is this used in half frame (stellar mode)? Check that and include it as a parameter in the json files if needed.
     obs_metadatas = classify(data_dir, naxis2_to_process)
@@ -984,6 +1020,9 @@ def main():
         "blue": "GRATINGB",
         "red": "GRATINGR",
     }
+
+    # SET SKIP ALREADY DONE FILES ?
+    skip_done = args.skip_done
 
     for arm in obs_metadatas.keys():
         try:
@@ -1019,32 +1058,68 @@ def main():
 
             os.makedirs(out_dir, exist_ok=True)
 
-            calib_prefix = os.path.join(out_dir, f"wifes_{arm}")
+            calib_prefix = f"wifes_{arm}"
+
 
             # Some WiFeS specific things
             my_data_hdu = 0
-
-            # SET SKIP ALREADY DONE FILES ?
-            skip_done = False
 
             # ------------------------------------------------------------------------
             # NAMES FOR MASTER CALIBRATION FILES!!!
             # ------------------------------------------------------------------------
 
-            superbias_fn = "%s_superbias.fits" % calib_prefix
-            superbias_fit_fn = "%s_superbias_fit.fits" % calib_prefix
-            super_dflat_raw = "%s_super_domeflat_raw.fits" % calib_prefix
-            super_dflat_fn = "%s_super_domeflat.fits" % calib_prefix
-            super_dflat_mef = "%s_super_domeflat_mef.fits" % calib_prefix
-            super_tflat_raw = "%s_super_twiflat_raw.fits" % calib_prefix
-            super_tflat_fn = "%s_super_twiflat.fits" % calib_prefix
-            super_tflat_mef = "%s_super_twiflat_mef.fits" % calib_prefix
-            slitlet_def_fn = "%s_slitlet_defs.pkl" % calib_prefix
-            wsol_out_fn = "%s_wave_soln.fits" % calib_prefix
-            wire_out_fn = "%s_wire_soln.fits" % calib_prefix
-            flat_resp_fn = "%s_resp_mef.fits" % calib_prefix
-            calib_fn = "%s_calib.pkl" % calib_prefix
-            tellcorr_fn = "%s_tellcorr.pkl" % calib_prefix
+            # Set path of calibrations 
+            if from_master:
+
+                master_path = os.path.abspath(from_master)
+            
+                print(f"Using blue parameters from: {master_path}")
+
+                # Bias Master Files
+                superbias_fn = os.path.join(master_path , "%s_superbias.fits" % calib_prefix)
+                
+                # Flat Master Files 
+                # Dome   
+                super_dflat_mef = os.path.join(master_path , "%s_super_domeflat_mef.fits" % calib_prefix)
+                # Twilight
+                super_tflat_mef = os.path.join(master_path , "%s_super_twiflat_mef.fits" % calib_prefix)
+            
+                # Slitlet definition
+                slitlet_def_fn = os.path.join(master_path , "%s_slitlet_defs.pkl" % calib_prefix)
+                wsol_out_fn = os.path.join(master_path , "%s_wave_soln.fits" % calib_prefix)
+
+                wire_out_fn = os.path.join(master_path , "%s_wire_soln.fits" % calib_prefix)
+                flat_resp_fn = os.path.join(master_path , "%s_resp_mef.fits" % calib_prefix)
+
+
+                tellcorr_fn = os.path.join(out_dir , "%s_tellcorr.pkl" % calib_prefix)
+                calib_fn = os.path.join(out_dir , "%s_calib.pkl" % calib_prefix)
+                superbias_fit_fn = os.path.join(out_dir , "%s_superbias_fit.fits" % calib_prefix)
+
+
+            else:
+                # Bias Master Files
+                superbias_fn = os.path.join(out_dir , "%s_superbias.fits" % calib_prefix)
+                superbias_fit_fn = os.path.join(out_dir , "%s_superbias_fit.fits" % calib_prefix)
+                
+                # Flat Master Files 
+                # Dome   
+                super_dflat_raw = os.path.join(out_dir , "%s_super_domeflat_raw.fits" % calib_prefix)
+                super_dflat_fn = os.path.join(out_dir , "%s_super_domeflat.fits" % calib_prefix)
+                super_dflat_mef = os.path.join(out_dir , "%s_super_domeflat_mef.fits" % calib_prefix)
+                # Twilight
+                super_tflat_raw = os.path.join(out_dir , "%s_super_twiflat_raw.fits" % calib_prefix)
+                super_tflat_fn = os.path.join(out_dir , "%s_super_twiflat.fits" % calib_prefix)
+                super_tflat_mef = os.path.join(out_dir , "%s_super_twiflat_mef.fits" % calib_prefix)
+            
+                # Slitlet definition
+                slitlet_def_fn = os.path.join(out_dir , "%s_slitlet_defs.pkl" % calib_prefix)
+               
+                wsol_out_fn = os.path.join(out_dir , "%s_wave_soln.fits" % calib_prefix)
+                wire_out_fn = os.path.join(out_dir , "%s_wire_soln.fits" % calib_prefix)
+                flat_resp_fn = os.path.join(out_dir , "%s_resp_mef.fits" % calib_prefix)
+                calib_fn = os.path.join(out_dir , "%s_calib.pkl" % calib_prefix)
+                tellcorr_fn = os.path.join(out_dir , "%s_tellcorr.pkl" % calib_prefix)
 
             # ------------------------------------------------------------------------
             # RUN THE PROCESSING STEPS

--- a/reduction_scripts/reduce_data.py
+++ b/reduction_scripts/reduce_data.py
@@ -1002,14 +1002,14 @@ def main():
     reduction_scripts_dir = os.path.dirname(__file__)
     working_dir = os.getcwd()
 
+    # Set to skip already done files
+    skip_done = args.skip_done
+
     # Set grism_key dictionary due to different keyword names for red and blue arms.
     grism_key = {
         "blue": "GRATINGB",
         "red": "GRATINGR",
     }
-
-    # SET SKIP ALREADY DONE FILES ?
-    skip_done = args.skip_done
 
     # Set the directory for master calibration files (default is ./data_products/master_calib/)
     # Define a list of steps to skip if the reduction is being performed using master calibration files
@@ -1048,9 +1048,16 @@ def main():
             if obs_metadata["sci"]:
                 reference_filename = obs_metadata["sci"][0]["sci"][0] + ".fits"
 
-                if not(obs_metadata["std"]):
-                    print(f"No standard star observations found. Standar calibrations skiped for the {arm} arm.")
-                    extra_skip_steps = extra_skip_steps + ['derive_telluric','telluric_corr','derive_calib', 'flux_calib']
+                if not (obs_metadata["std"]):
+                    print(
+                        f"No standard star observations found. Standar calibrations skiped for the {arm} arm."
+                    )
+                    extra_skip_steps = extra_skip_steps + [
+                        "derive_telluric",
+                        "telluric_corr",
+                        "derive_calib",
+                        "flux_calib",
+                    ]
 
             elif obs_metadata["std"]:
                 reference_filename = obs_metadata["std"][0]["sci"][0] + ".fits"
@@ -1058,10 +1065,17 @@ def main():
             elif obs_metadata["arc"]:
                 reference_filename = obs_metadata["arc"][0] + ".fits"
 
-                print(f"No science or standard star observations found. Only master calibration files will produced for the {arm} arm.")
+                print(
+                    f"No science or standard star observations found. Only master calibration files will produced for the {arm} arm."
+                )
 
-                extra_skip_steps = extra_skip_steps + ['derive_telluric','telluric_corr','derive_calib','flux_calib','save_3dcube']
-
+                extra_skip_steps = extra_skip_steps + [
+                    "derive_telluric",
+                    "telluric_corr",
+                    "derive_calib",
+                    "flux_calib",
+                    "save_3dcube",
+                ]
 
             # Check observing mode
             if pywifes.is_nodshuffle(data_dir + reference_filename):
@@ -1139,8 +1153,6 @@ def main():
             # When reducing from master calibration files, if the tellic_correction file is already among the master calibrations, skip its generation.
             if from_master and os.path.exists(tellcorr_fn):
                 extra_skip_steps.append("derive_calib")
-
-
 
             # ------------------------------------------------------------------------
             # Run proccessing steps

--- a/src/pywifes/pywifes.py
+++ b/src/pywifes/pywifes.py
@@ -13,7 +13,7 @@ import scipy.interpolate as interp
 import pylab
 import matplotlib.pyplot as plt
 import pylab
-import  astropy.units as u
+import astropy.units as u
 
 from .multiprocessing_utils import get_task, map_tasks
 from .wifes_metadata import metadata_dir
@@ -25,120 +25,118 @@ from .mpfit import mpfit
 # CODE VERSION
 from .wifes_metadata import __version__
 
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 # NEED TO OPEN / ACCESS WIFES METADATA FILE!!
-f0 = open(os.path.join(metadata_dir,'basic_wifes_metadata.pkl'), 'rb')
+f0 = open(os.path.join(metadata_dir, "basic_wifes_metadata.pkl"), "rb")
 try:
-    wifes_metadata = pickle.load(f0, fix_imports=True, encoding='latin')
+    wifes_metadata = pickle.load(f0, fix_imports=True, encoding="latin")
 except:
-    wifes_metadata = pickle.load(f0) # fix_imports doesn't work in python 2.7.
+    wifes_metadata = pickle.load(f0)  # fix_imports doesn't work in python 2.7.
 f0.close()
-blue_slitlet_defs = wifes_metadata['blue_slitlet_defs']
-red_slitlet_defs = wifes_metadata['red_slitlet_defs']
+blue_slitlet_defs = wifes_metadata["blue_slitlet_defs"]
+red_slitlet_defs = wifes_metadata["red_slitlet_defs"]
 nslits = len(blue_slitlet_defs.keys())
 
-#------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------
 # functions that operate on data rather than images
-def single_centroid_prof_fit(y,
-                             x=None,
-                             ctr_guess=None,
-                             width_guess=None,
-                             return_width=False):
+def single_centroid_prof_fit(
+    y, x=None, ctr_guess=None, width_guess=None, return_width=False
+):
     N = len(y)
     if x is None:
-        x = numpy.arange(N,dtype='d')
+        x = numpy.arange(N, dtype="d")
     # choose x,y subregions for this line
     if ctr_guess != None and width_guess != None:
-        ifit_lo = ctr_guess-5*width_guess
-        ifit_hi = ctr_guess+5*width_guess
+        ifit_lo = ctr_guess - 5 * width_guess
+        ifit_hi = ctr_guess + 5 * width_guess
     else:
         ifit_lo = 0
         ifit_hi = N
     xfit = x[ifit_lo:ifit_hi]
     yfit = y[ifit_lo:ifit_hi]
-    new_xctr = numpy.sum(xfit*(yfit**2))/numpy.sum((yfit**2))
-    new_x2 = numpy.sum(((xfit-new_xctr)**2)*(yfit**2))/numpy.sum((yfit**2))
+    new_xctr = numpy.sum(xfit * (yfit**2)) / numpy.sum((yfit**2))
+    new_x2 = numpy.sum(((xfit - new_xctr) ** 2) * (yfit**2)) / numpy.sum((yfit**2))
     new_rms = new_x2**0.5
-    new_sig = new_rms/2.235
+    new_sig = new_rms / 2.235
     if return_width:
         return new_xctr, new_sig
     else:
         return new_xctr
 
-#------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------
 # high-level functions to check if an observation is half-frame or N+S
 def is_halfframe(inimg, data_hdu=0):
     f = pyfits.open(inimg)
-    detsec = f[data_hdu].header['DETSEC']
+    detsec = f[data_hdu].header["DETSEC"]
     f.close()
-    ystart = int(float(detsec.split(',')[1].split(':')[0]))
+    ystart = int(float(detsec.split(",")[1].split(":")[0]))
     return ystart > 2000
 
 
 def is_nodshuffle(inimg, data_hdu=0):
     f = pyfits.open(inimg)
-    ns = f[data_hdu].header['WIFESOBS']
+    ns = f[data_hdu].header["WIFESOBS"]
     f.close()
-    return ns == 'NodAndShuffle'
+    return ns == "NodAndShuffle"
+
 
 def is_subnodshuffle(inimg, data_hdu=0):
     f = pyfits.open(inimg)
-    sns = f[data_hdu].header['WIFESOBS']
+    sns = f[data_hdu].header["WIFESOBS"]
     f.close()
-    return sns == 'SubNodAndShuffle'
+    return sns == "SubNodAndShuffle"
 
 
-#------------------------------------------------------------------------
-def imcombine(inimg_list, outimg,
-              method='median',
-              scale=None,
-              data_hdu=0):
+# ------------------------------------------------------------------------
+def imcombine(inimg_list, outimg, method="median", scale=None, data_hdu=0):
     # read in data from inimg_list[0] to get image size
     f = pyfits.open(inimg_list[0])
     outfits = pyfits.HDUList(f)
     orig_data = f[data_hdu].data
-    orig_hdr  = f[data_hdu].header
+    orig_hdr = f[data_hdu].header
     f.close()
     nimg = len(inimg_list)
     ny, nx = numpy.shape(orig_data)
-    coadd_arr = numpy.zeros([ny, nx, nimg],dtype='d')
-    coadd_arr[:,:,0] = orig_data
+    coadd_arr = numpy.zeros([ny, nx, nimg], dtype="d")
+    coadd_arr[:, :, 0] = orig_data
     # gather data for all
     exptime_list = []
     airmass_list = []
     for i in range(nimg):
         f = pyfits.open(inimg_list[i])
         new_data = f[data_hdu].data
-        exptime_list.append(f[data_hdu].header['EXPTIME'])
+        exptime_list.append(f[data_hdu].header["EXPTIME"])
         try:
-            airmass_list.append(f[data_hdu].header['AIRMASS'])
+            airmass_list.append(f[data_hdu].header["AIRMASS"])
         except:
             airmass_list.append(1.0)
         f.close()
         if scale == None:
             scale_factor = 1.0
-        elif scale == 'median':
+        elif scale == "median":
             scale_factor = numpy.median(new_data)
-        elif scale == 'median_nonzero':
+        elif scale == "median_nonzero":
             nonzero_inds = numpy.nonzero(new_data > 100.0)
             scale_factor = numpy.median(new_data[nonzero_inds])
-        elif scale == 'exptime':
+        elif scale == "exptime":
             scale_factor = exptime_list[-1]
         else:
-            raise ValueError('scaling method not yet supported')
-        coadd_arr[:,:,i] = new_data/scale_factor
+            raise ValueError("scaling method not yet supported")
+        coadd_arr[:, :, i] = new_data / scale_factor
         # later - scale data by some value, e.g. median or exptime
         gc.collect()
     # now do median (or something else - tbd later)
-    if method == 'median':
-        coadd_data = numpy.median(coadd_arr,axis=2)
-    elif method == 'sum':
-        coadd_data = numpy.sum(coadd_arr,axis=2)
+    if method == "median":
+        coadd_data = numpy.median(coadd_arr, axis=2)
+    elif method == "sum":
+        coadd_data = numpy.sum(coadd_arr, axis=2)
     else:
-        raise ValueError('combine method not yet supported')
+        raise ValueError("combine method not yet supported")
     outfits[data_hdu].data = coadd_data
     # fix ephemeris data if images are co-added!!!
-    if method == 'sum' and scale == None:
+    if method == "sum" and scale == None:
         f1 = pyfits.open(inimg_list[0])
         first_hdr = f1[data_hdu].header
         f1.close()
@@ -146,37 +144,34 @@ def imcombine(inimg_list, outimg,
         last_hdr = f2[data_hdu].header
         f2.close()
         # HAEND, ZDEND, EXPTIME
-        outfits[data_hdu].header.set(
-            'EXPTIME', sum(exptime_list))
-        outfits[data_hdu].header.set(
-            'LSTEND', last_hdr['LSTEND'])
-        outfits[data_hdu].header.set(
-            'UTCEND', last_hdr['UTCEND'])
-        outfits[data_hdu].header.set(
-            'HAEND', last_hdr['HAEND'])
-        outfits[data_hdu].header.set(
-            'ZDEND', last_hdr['ZDEND'])
-        outfits[data_hdu].header.set(
-            'AIRMASS',
-            numpy.mean(numpy.array(airmass_list)))
+        outfits[data_hdu].header.set("EXPTIME", sum(exptime_list))
+        outfits[data_hdu].header.set("LSTEND", last_hdr["LSTEND"])
+        outfits[data_hdu].header.set("UTCEND", last_hdr["UTCEND"])
+        outfits[data_hdu].header.set("HAEND", last_hdr["HAEND"])
+        outfits[data_hdu].header.set("ZDEND", last_hdr["ZDEND"])
+        outfits[data_hdu].header.set("AIRMASS", numpy.mean(numpy.array(airmass_list)))
     # (5) write to outfile!
-    outfits[data_hdu].header.set('PYWIFES', __version__, 'PyWiFeS version')
+    outfits[data_hdu].header.set("PYWIFES", __version__, "PyWiFeS version")
     outfits.writeto(outimg, overwrite=True)
     gc.collect()
     return
 
-def imcombine_mef(inimg_list, outimg,
-                  data_hdu_list = list(range(1,26)),
-                  var_hdu_list = list(range(26,51)),
-                  dq_hdu_list = list(range(51,76)),
-                  scale=None,
-                  method='median'):
+
+def imcombine_mef(
+    inimg_list,
+    outimg,
+    data_hdu_list=list(range(1, 26)),
+    var_hdu_list=list(range(26, 51)),
+    dq_hdu_list=list(range(51, 76)),
+    scale=None,
+    method="median",
+):
     nimg = len(inimg_list)
     # read in data from inimg_list[0] to get image size
     f = pyfits.open(inimg_list[0])
     outfits = pyfits.HDUList(f)
     # eventually will have different methods for each...
-    for data_hdu in data_hdu_list+var_hdu_list+dq_hdu_list:
+    for data_hdu in data_hdu_list + var_hdu_list + dq_hdu_list:
         orig_data = f[data_hdu].data
         ny, nx = numpy.shape(orig_data)
         coadd_arr = numpy.zeros([ny, nx, nimg])
@@ -184,39 +179,39 @@ def imcombine_mef(inimg_list, outimg,
         for i in range(nimg):
             f2 = pyfits.open(inimg_list[i])
             new_data = f2[data_hdu].data
-            exptime = f2[data_hdu].header['EXPTIME']
+            exptime = f2[data_hdu].header["EXPTIME"]
             f2.close()
             if scale == None:
                 scale_factor = 1.0
-            elif scale == 'median':
+            elif scale == "median":
                 scale_factor = numpy.median(new_data)
-            elif scale == 'exptime':
+            elif scale == "exptime":
                 scale_factor = exptime
             else:
-                raise ValueError('scaling method not yet supported')
-            coadd_arr[:,:,i] = new_data/scale_factor
+                raise ValueError("scaling method not yet supported")
+            coadd_arr[:, :, i] = new_data / scale_factor
             # later - scale data by some value, e.g. median or exptime
             gc.collect()
         # now do median (or something else - tbd later)
-        if method == 'median':
-            coadd_data = numpy.median(coadd_arr,axis=2)
-        elif method == 'sum':
-            coadd_data = numpy.sum(coadd_arr,axis=2)
+        if method == "median":
+            coadd_data = numpy.median(coadd_arr, axis=2)
+        elif method == "sum":
+            coadd_data = numpy.sum(coadd_arr, axis=2)
         else:
-            raise ValueError('combine method not yet supported')
+            raise ValueError("combine method not yet supported")
         outfits[data_hdu].data = coadd_data
         gc.collect()
     # fix ephemeris data if images are co-added!!!
-    if method == 'sum' and scale == None:
+    if method == "sum" and scale == None:
         airmass_list = []
         exptime_list = []
         for i in range(nimg):
             f2 = pyfits.open(inimg_list[i])
             try:
-                airmass_list.append(f2[1].header['AIRMASS'])
+                airmass_list.append(f2[1].header["AIRMASS"])
             except:
                 pass
-            exptime_list.append(f2[1].header['EXPTIME'])
+            exptime_list.append(f2[1].header["EXPTIME"])
             f2.close()
         f1 = pyfits.open(inimg_list[0])
         first_hdr = f1[1].header
@@ -225,54 +220,48 @@ def imcombine_mef(inimg_list, outimg,
         last_hdr = f2[1].header
         f2.close()
         # HAEND, ZDEND, EXPTIME
-        outfits[1].header.set(
-            'EXPTIME', sum(exptime_list))
+        outfits[1].header.set("EXPTIME", sum(exptime_list))
         try:
-            outfits[1].header.set(
-                'LSTEND', last_hdr['LSTEND'])
+            outfits[1].header.set("LSTEND", last_hdr["LSTEND"])
         except:
             pass
         try:
-            outfits[1].header.set(
-                'UTCEND', last_hdr['UTCEND'])
+            outfits[1].header.set("UTCEND", last_hdr["UTCEND"])
         except:
             pass
         try:
-            outfits[1].header.set(
-                'HAEND', last_hdr['HAEND'])
+            outfits[1].header.set("HAEND", last_hdr["HAEND"])
         except:
             pass
         try:
-            outfits[1].header.set(
-                'ZDEND', last_hdr['ZDEND'])
+            outfits[1].header.set("ZDEND", last_hdr["ZDEND"])
         except:
             pass
         if len(airmass_list) > 0:
-            outfits[1].header.set(
-                'AIRMASS',
-                numpy.mean(numpy.array(airmass_list)))
+            outfits[1].header.set("AIRMASS", numpy.mean(numpy.array(airmass_list)))
     # (5) write to outfile!
-    outfits[0].header.set('PYWIFES', __version__, 'PyWiFeS version')
-    outfits[1].header.set('PYWIFES', __version__, 'PyWiFeS version')
+    outfits[0].header.set("PYWIFES", __version__, "PyWiFeS version")
+    outfits[1].header.set("PYWIFES", __version__, "PyWiFeS version")
     outfits.writeto(outimg, overwrite=True)
     f.close()
     gc.collect()
     return
 
-#------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------
 def imarith_mef(inimg1, operator, inimg2, outimg):
     # check if halfframe
     halfframe = is_halfframe(inimg1)
     if halfframe:
         nslits = 12
-        data_hdu_list = range(1,13)
-        var_hdu_list = range(26,38)
-        dq_hdu_list = range(51,63)
+        data_hdu_list = range(1, 13)
+        var_hdu_list = range(26, 38)
+        dq_hdu_list = range(51, 63)
     else:
         nslits = 25
-        data_hdu_list = range(1,26)
-        var_hdu_list = range(26,51)
-        dq_hdu_list = range(51,76)
+        data_hdu_list = range(1, 26)
+        var_hdu_list = range(26, 51)
+        dq_hdu_list = range(51, 76)
     # read in data from the two images, set up the output hdu
     f1 = pyfits.open(inimg1)
     f2 = pyfits.open(inimg2)
@@ -282,14 +271,14 @@ def imarith_mef(inimg1, operator, inimg2, outimg):
         data1 = f1[data_hdu].data
         data2 = f2[data_hdu].data
         # do the desired operation
-        if operator == '+':
-            op_data = data1+data2
-        elif operator == '-':
-            op_data = data1-data2
-        elif operator == '*':
-            op_data = data1*data2
-        elif operator == '/':
-            op_data = data1/data2
+        if operator == "+":
+            op_data = data1 + data2
+        elif operator == "-":
+            op_data = data1 - data2
+        elif operator == "*":
+            op_data = data1 * data2
+        elif operator == "/":
+            op_data = data1 / data2
         else:
             raise ValueError
         outfits[data_hdu].data = op_data
@@ -307,12 +296,12 @@ def imarith_mef(inimg1, operator, inimg2, outimg):
         except:
             continue
         # do the desired operation
-        if (operator == '+') or (operator == '-'):
-            op_var = var1+var2
-        elif operator == '*':
-            op_var = var1*(data2**2)+var2*(data1**2)
-        elif operator == '/':
-            op_var = var1/(data2**2) +var2*((data1/(data2**2))**2)
+        if (operator == "+") or (operator == "-"):
+            op_var = var1 + var2
+        elif operator == "*":
+            op_var = var1 * (data2**2) + var2 * (data1**2)
+        elif operator == "/":
+            op_var = var1 / (data2**2) + var2 * ((data1 / (data2**2)) ** 2)
         else:
             raise ValueError
         outfits[var_hdu].data = op_var
@@ -325,31 +314,31 @@ def imarith_mef(inimg1, operator, inimg2, outimg):
         except:
             continue
         # always add the DQ images!!
-        op_dq = dq1+dq2
+        op_dq = dq1 + dq2
         outfits[dq_hdu].data = op_dq
         gc.collect()
     # (5) write to outfile!
-    outfits[0].header.set('PYWIFES', __version__, 'PyWiFeS version')
+    outfits[0].header.set("PYWIFES", __version__, "PyWiFeS version")
     outfits.writeto(outimg, overwrite=True)
     f1.close()
     f2.close()
     gc.collect()
     return
 
-def scaled_imarith_mef(inimg1, operator, inimg2, outimg,
-                       scale=None):
+
+def scaled_imarith_mef(inimg1, operator, inimg2, outimg, scale=None):
     # check if halfframe
     halfframe = is_halfframe(inimg1)
     if halfframe:
         nslits = 12
-        data_hdu_list = range(1,13)
-        var_hdu_list = range(26,38)
-        dq_hdu_list = range(51,63)
+        data_hdu_list = range(1, 13)
+        var_hdu_list = range(26, 38)
+        dq_hdu_list = range(51, 63)
     else:
         nslits = 25
-        data_hdu_list = range(1,26)
-        var_hdu_list = range(26,51)
-        dq_hdu_list = range(51,76)
+        data_hdu_list = range(1, 26)
+        var_hdu_list = range(26, 51)
+        dq_hdu_list = range(51, 76)
     # read in data from the two images, set up the output hdu
     f1 = pyfits.open(inimg1)
     f2 = pyfits.open(inimg2)
@@ -357,25 +346,25 @@ def scaled_imarith_mef(inimg1, operator, inimg2, outimg,
     # calculate the scale factor!
     if type(scale) == type(1.0):
         scale_factor = scale
-    elif scale == 'exptime':
-        exptime1 = f1[1].header['EXPTIME']
-        exptime2 = f2[1].header['EXPTIME']
-        scale_factor = exptime1/exptime2
+    elif scale == "exptime":
+        exptime1 = f1[1].header["EXPTIME"]
+        exptime2 = f2[1].header["EXPTIME"]
+        scale_factor = exptime1 / exptime2
     else:
         scale_factor = 1.0
     # PART 1 - data HDUs
     for data_hdu in data_hdu_list:
         data1 = f1[data_hdu].data
-        data2 = scale_factor*(f2[data_hdu].data)
+        data2 = scale_factor * (f2[data_hdu].data)
         # do the desired operation
-        if operator == '+':
-            op_data = data1+data2
-        elif operator == '-':
-            op_data = data1-data2
-        elif operator == '*':
-            op_data = data1*data2
-        elif operator == '/':
-            op_data = data1/data2
+        if operator == "+":
+            op_data = data1 + data2
+        elif operator == "-":
+            op_data = data1 - data2
+        elif operator == "*":
+            op_data = data1 * data2
+        elif operator == "/":
+            op_data = data1 / data2
         else:
             raise ValueError
         outfits[data_hdu].data = op_data
@@ -385,16 +374,16 @@ def scaled_imarith_mef(inimg1, operator, inimg2, outimg,
         var_hdu = var_hdu_list[i]
         data_hdu = data_hdu_list[i]
         var1 = f1[var_hdu].data
-        var2 = (scale_factor**2)*(f2[var_hdu].data)
+        var2 = (scale_factor**2) * (f2[var_hdu].data)
         data1 = f1[data_hdu].data
-        data2 = scale_factor*(f2[data_hdu].data)
+        data2 = scale_factor * (f2[data_hdu].data)
         # do the desired operation
-        if (operator == '+') or (operator == '-'):
-            op_var = var1+var2
-        elif operator == '*':
-            op_var = var1*(data2**2)+var2*(data1**2)
-        elif operator == '/':
-            op_var = var1/(data2**2) +var2*((data1/(data2**2))**2)
+        if (operator == "+") or (operator == "-"):
+            op_var = var1 + var2
+        elif operator == "*":
+            op_var = var1 * (data2**2) + var2 * (data1**2)
+        elif operator == "/":
+            op_var = var1 / (data2**2) + var2 * ((data1 / (data2**2)) ** 2)
         else:
             raise ValueError
         outfits[var_hdu].data = op_var
@@ -403,14 +392,15 @@ def scaled_imarith_mef(inimg1, operator, inimg2, outimg,
         dq1 = f1[dq_hdu].data
         dq2 = f2[dq_hdu].data
         # always add the DQ images!!
-        op_dq = dq1+dq2
+        op_dq = dq1 + dq2
         outfits[dq_hdu].data = op_dq
     # (5) write to outfile!
-    outfits[0].header.set('PYWIFES', __version__, 'PyWiFeS version')
+    outfits[0].header.set("PYWIFES", __version__, "PyWiFeS version")
     outfits.writeto(outimg, overwrite=True)
     f1.close()
     f2.close()
     return
+
 
 def imarith(inimg1, operator, inimg2, outimg, data_hdu=0):
     f1 = pyfits.open(inimg1)
@@ -419,36 +409,37 @@ def imarith(inimg1, operator, inimg2, outimg, data_hdu=0):
     data1 = f1[data_hdu].data
     data2 = f2[data_hdu].data
     # do the desired operation
-    if operator == '+':
-        op_data = data1+data2
-    elif operator == '-':
-        op_data = data1-data2
-    elif operator == '*':
-        op_data = data1*data2
-    elif operator == '/':
-        op_data = data1/data2
+    if operator == "+":
+        op_data = data1 + data2
+    elif operator == "-":
+        op_data = data1 - data2
+    elif operator == "*":
+        op_data = data1 * data2
+    elif operator == "/":
+        op_data = data1 / data2
     else:
         raise ValueError
     outfits[data_hdu].data = op_data
-    outfits[data_hdu].header.set('PYWIFES', __version__, 'PyWiFeS version')
+    outfits[data_hdu].header.set("PYWIFES", __version__, "PyWiFeS version")
     outfits.writeto(outimg, overwrite=True)
     f1.close()
     f2.close()
     return
+
 
 def imarith_float_mef(inimg1, operator, scale, outimg):
     # check if halfframe
     halfframe = is_halfframe(inimg1)
     if halfframe:
         nslits = 12
-        data_hdu_list = range(1,13)
-        var_hdu_list = range(26,38)
-        dq_hdu_list = range(51,63)
+        data_hdu_list = range(1, 13)
+        var_hdu_list = range(26, 38)
+        dq_hdu_list = range(51, 63)
     else:
         nslits = 25
-        data_hdu_list = range(1,26)
-        var_hdu_list = range(26,51)
-        dq_hdu_list = range(51,76)
+        data_hdu_list = range(1, 26)
+        var_hdu_list = range(26, 51)
+        dq_hdu_list = range(51, 76)
     # read in data from the two images, set up the output hdu
     f1 = pyfits.open(inimg1)
     outfits = pyfits.HDUList(f1)
@@ -456,14 +447,14 @@ def imarith_float_mef(inimg1, operator, scale, outimg):
     for data_hdu in data_hdu_list:
         data1 = f1[data_hdu].data
         # do the desired operation
-        if operator == '+':
-            op_data = data1+scale
-        elif operator == '-':
-            op_data = data1-scale
-        elif operator == '*':
-            op_data = data1*scale
-        elif operator == '/':
-            op_data = data1/scale
+        if operator == "+":
+            op_data = data1 + scale
+        elif operator == "-":
+            op_data = data1 - scale
+        elif operator == "*":
+            op_data = data1 * scale
+        elif operator == "/":
+            op_data = data1 / scale
         else:
             raise ValueError
         outfits[data_hdu].data = op_data
@@ -475,12 +466,12 @@ def imarith_float_mef(inimg1, operator, scale, outimg):
         var1 = f1[var_hdu].data
         data1 = f1[data_hdu].data
         # do the desired operation
-        if (operator == '+') or (operator == '-'):
+        if (operator == "+") or (operator == "-"):
             op_var = var1
-        elif operator == '*':
-            op_var = var1*(scale**2)
-        elif operator == '/':
-            op_var = var1/(scale**2)
+        elif operator == "*":
+            op_var = var1 * (scale**2)
+        elif operator == "/":
+            op_var = var1 / (scale**2)
         else:
             raise ValueError
         outfits[var_hdu].data = op_var
@@ -491,16 +482,23 @@ def imarith_float_mef(inimg1, operator, scale, outimg):
         op_dq = dq1
         outfits[dq_hdu].data = op_dq
     # (5) write to outfile!
-    outfits[0].header.set('PYWIFES', __version__, 'PyWiFeS version')
+    outfits[0].header.set("PYWIFES", __version__, "PyWiFeS version")
     outfits.writeto(outimg, overwrite=True)
     f1.close()
     return
 
+
 def imarith_float(inimg1, operator, scale, outimg, data_hdu=0):
-    return imarith_float_mef(inimg1, operator, scale, outimg,
-                             data_hdu_list=[data_hdu],
-                             var_hdu_list=[],
-                             dq_hdu_list=[])
+    return imarith_float_mef(
+        inimg1,
+        operator,
+        scale,
+        outimg,
+        data_hdu_list=[data_hdu],
+        var_hdu_list=[],
+        dq_hdu_list=[],
+    )
+
 
 def imcopy(inimg, outimg):
     f = pyfits.open(inimg)
@@ -509,7 +507,8 @@ def imcopy(inimg, outimg):
     f.close()
     return
 
-#------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------
 # OVERSCAN SUBTRACTION
 #### Default values for 1x1 binning
 ###default_det_reg_bin1x1 = [[1,4096,62,2109],
@@ -525,137 +524,199 @@ def imcopy(inimg, outimg):
 ###                          [1,2048,48,61]]
 
 default_detector_values = {
-    'B1' : {'det_regs' : [[1,2048,22,2069],
-                          [1,2048,2070,4117],
-                          [2049,4096,2070,4117],
-                          [2049,4096,22,2069]],
-            'ovs_regs' : [[1,2048,8,17],
-                          [1,2048,4122,4131],
-                          [2049,4096,4122,4131],
-                          [2049,4096,8,17]],
-            'sci_regs' : [[1,2048,1,2048],
-                          [1,2048,2049,4096],
-                          [2049,4096,2049,4096],
-                          [2049,4096,1,2048]],
-            'gain'     : [0.82, 0.92, 0.92, 0.96],
-            'rdnoise'  : [7.9, 8.95, 4.4, 5.7]},
-    'B2' : {'det_regs' : [[1,2048,19,2066],
-                          [1,2048,2115,4162],
-                          [2049,4096,2115,4162],
-                          [2049,4096,19,2066]],
-            'ovs_regs' : [[1,2048,7,14],
-                          [1,2048,4166,4173],
-                          [2049,4096,4166,4173],
-                          [2049,4096,7,14]],
-            'sci_regs' : [[1,2048,1,2048],
-                          [1,2048,2049,4096],
-                          [2049,4096,2049,4096],
-                          [2049,4096,1,2048]],
-            'gain'     : [0.82, 0.92, 0.92, 0.96],
-            'rdnoise'  : [7.9, 8.95, 4.4, 5.7]},
-    'B3' : {'det_regs' : [[1,4096,62,2109],
-                          [1,4096,2115,4162]],
-            'ovs_regs' : [[1,4096,14,40],
-                          [1,4096,14,40]],
-            'sci_regs' : [[1,4096,1,2048],
-                          [1,4096,2049,4096]],
-            'gain'     : [1.0, 1.0],
-            'rdnoise'  : [7.0, 7.0]},
-    'B4' : {'det_regs' : [[1,4096,54,4149],],
-            'ovs_regs' : [[1,4096,6,53],],
-            'sci_regs' : [[1,4096,1,4096],],
-            'gain'     : [1.0],
-             'rdnoise'  : [7.0]},
-    'R1' : {'det_regs' : [[1,2048,22,2069],
-                          [1,2048,2070,4117],
-                          [2049,4096,2070,4117],
-                          [2049,4096,22,2069]],
-            'ovs_regs' : [[1,2048,8,17],
-                          [1,2048,4122,4131],
-                          [2049,4096,4122,4131],
-                          [2049,4096,8,17]],
-            'sci_regs' : [[1,2048,1,2048],
-                          [1,2048,2049,4096],
-                          [2049,4096,2049,4096],
-                          [2049,4096,1,2048]],
-            'gain'     : [1.01, 0.98, 1.02, 0.84],
-            'rdnoise'  : [4.4, 7.0, 5.2, 5.0]},
-    'R2' : {'det_regs' : [[1,2048,19,2066],
-                          [1,2048,2115,4162],
-                          [2049,4096,2115,4162],
-                          [2049,4096,19,2066]],
-            'ovs_regs' : [[1,2048,7,14],
-                          [1,2048,4166,4173],
-                          [2049,4096,4166,4173],
-                          [2049,4096,7,14]],
-            'sci_regs' : [[1,2048,1,2048],
-                          [1,2048,2049,4096],
-                          [2049,4096,2049,4096],
-                          [2049,4096,1,2048]],
-            'gain'     : [1.01, 0.98, 1.02, 0.84],
-            'rdnoise'  : [4.4, 7.0, 5.2, 5.0]},
-    'R3' : {'det_regs' : [[1,4096,62,2109],
-                          [1,4096,2115,4162]],
-            'ovs_regs' : [[1,4096,14,40],
-                          [1,4096,14,40]],
-            'sci_regs' : [[1,4096,1,2048],
-                          [1,4096,2049,4096]],
-            'gain'     : [1.0, 1.0],
-            'rdnoise'  : [7.0, 7.0]},
-    'R4a' : {'det_regs' : [[1,4096,64,4159],],
-             'ovs_regs' : [[1,4096,1,63],],
-             'sci_regs' : [[1,4096,1,4096],],
-             'gain'     : [1.0],
-             'rdnoise'  : [7.0]},
-    'R4' : {'det_regs' : [[1,4096,54,4149],],
-            'ovs_regs' : [[1,4096,6,53],],
-            'sci_regs' : [[1,4096,1,4096],],
-            'gain'     : [1.0],
-             'rdnoise'  : [7.0]},
-    }
+    "B1": {
+        "det_regs": [
+            [1, 2048, 22, 2069],
+            [1, 2048, 2070, 4117],
+            [2049, 4096, 2070, 4117],
+            [2049, 4096, 22, 2069],
+        ],
+        "ovs_regs": [
+            [1, 2048, 8, 17],
+            [1, 2048, 4122, 4131],
+            [2049, 4096, 4122, 4131],
+            [2049, 4096, 8, 17],
+        ],
+        "sci_regs": [
+            [1, 2048, 1, 2048],
+            [1, 2048, 2049, 4096],
+            [2049, 4096, 2049, 4096],
+            [2049, 4096, 1, 2048],
+        ],
+        "gain": [0.82, 0.92, 0.92, 0.96],
+        "rdnoise": [7.9, 8.95, 4.4, 5.7],
+    },
+    "B2": {
+        "det_regs": [
+            [1, 2048, 19, 2066],
+            [1, 2048, 2115, 4162],
+            [2049, 4096, 2115, 4162],
+            [2049, 4096, 19, 2066],
+        ],
+        "ovs_regs": [
+            [1, 2048, 7, 14],
+            [1, 2048, 4166, 4173],
+            [2049, 4096, 4166, 4173],
+            [2049, 4096, 7, 14],
+        ],
+        "sci_regs": [
+            [1, 2048, 1, 2048],
+            [1, 2048, 2049, 4096],
+            [2049, 4096, 2049, 4096],
+            [2049, 4096, 1, 2048],
+        ],
+        "gain": [0.82, 0.92, 0.92, 0.96],
+        "rdnoise": [7.9, 8.95, 4.4, 5.7],
+    },
+    "B3": {
+        "det_regs": [[1, 4096, 62, 2109], [1, 4096, 2115, 4162]],
+        "ovs_regs": [[1, 4096, 14, 40], [1, 4096, 14, 40]],
+        "sci_regs": [[1, 4096, 1, 2048], [1, 4096, 2049, 4096]],
+        "gain": [1.0, 1.0],
+        "rdnoise": [7.0, 7.0],
+    },
+    "B4": {
+        "det_regs": [
+            [1, 4096, 54, 4149],
+        ],
+        "ovs_regs": [
+            [1, 4096, 6, 53],
+        ],
+        "sci_regs": [
+            [1, 4096, 1, 4096],
+        ],
+        "gain": [1.0],
+        "rdnoise": [7.0],
+    },
+    "R1": {
+        "det_regs": [
+            [1, 2048, 22, 2069],
+            [1, 2048, 2070, 4117],
+            [2049, 4096, 2070, 4117],
+            [2049, 4096, 22, 2069],
+        ],
+        "ovs_regs": [
+            [1, 2048, 8, 17],
+            [1, 2048, 4122, 4131],
+            [2049, 4096, 4122, 4131],
+            [2049, 4096, 8, 17],
+        ],
+        "sci_regs": [
+            [1, 2048, 1, 2048],
+            [1, 2048, 2049, 4096],
+            [2049, 4096, 2049, 4096],
+            [2049, 4096, 1, 2048],
+        ],
+        "gain": [1.01, 0.98, 1.02, 0.84],
+        "rdnoise": [4.4, 7.0, 5.2, 5.0],
+    },
+    "R2": {
+        "det_regs": [
+            [1, 2048, 19, 2066],
+            [1, 2048, 2115, 4162],
+            [2049, 4096, 2115, 4162],
+            [2049, 4096, 19, 2066],
+        ],
+        "ovs_regs": [
+            [1, 2048, 7, 14],
+            [1, 2048, 4166, 4173],
+            [2049, 4096, 4166, 4173],
+            [2049, 4096, 7, 14],
+        ],
+        "sci_regs": [
+            [1, 2048, 1, 2048],
+            [1, 2048, 2049, 4096],
+            [2049, 4096, 2049, 4096],
+            [2049, 4096, 1, 2048],
+        ],
+        "gain": [1.01, 0.98, 1.02, 0.84],
+        "rdnoise": [4.4, 7.0, 5.2, 5.0],
+    },
+    "R3": {
+        "det_regs": [[1, 4096, 62, 2109], [1, 4096, 2115, 4162]],
+        "ovs_regs": [[1, 4096, 14, 40], [1, 4096, 14, 40]],
+        "sci_regs": [[1, 4096, 1, 2048], [1, 4096, 2049, 4096]],
+        "gain": [1.0, 1.0],
+        "rdnoise": [7.0, 7.0],
+    },
+    "R4a": {
+        "det_regs": [
+            [1, 4096, 64, 4159],
+        ],
+        "ovs_regs": [
+            [1, 4096, 1, 63],
+        ],
+        "sci_regs": [
+            [1, 4096, 1, 4096],
+        ],
+        "gain": [1.0],
+        "rdnoise": [7.0],
+    },
+    "R4": {
+        "det_regs": [
+            [1, 4096, 54, 4149],
+        ],
+        "ovs_regs": [
+            [1, 4096, 6, 53],
+        ],
+        "sci_regs": [
+            [1, 4096, 1, 4096],
+        ],
+        "gain": [1.0],
+        "rdnoise": [7.0],
+    },
+}
+
 
 def determine_detector_epoch(inimg, data_hdu=0):
     f = pyfits.open(inimg)
     orig_hdr = f[data_hdu].header
     f.close()
-    utc_str = orig_hdr['DATE-OBS'].split('T')[0]
-    utc_date = int(float(utc_str.replace('-','')))
-    camera = orig_hdr['CAMERA']
-    if camera == 'WiFeSRed':
+    utc_str = orig_hdr["DATE-OBS"].split("T")[0]
+    utc_date = int(float(utc_str.replace("-", "")))
+    camera = orig_hdr["CAMERA"]
+    if camera == "WiFeSRed":
         if utc_date < 20100511:
-            epoch = 'R1'
+            epoch = "R1"
         elif utc_date < 20100801:
-            epoch = 'R2'
+            epoch = "R2"
         elif utc_date < 20130225:
-            epoch = 'R3'
+            epoch = "R3"
         elif utc_date < 20130322:
-            epoch = 'R4a'
+            epoch = "R4a"
         else:
-            epoch = 'R4'
+            epoch = "R4"
     else:
         if utc_date < 20100511:
-            epoch = 'B1'
+            epoch = "B1"
         elif utc_date < 20110616:
-            epoch = 'B2'
+            epoch = "B2"
         elif utc_date < 20130522:
-            epoch = 'B3'
+            epoch = "B3"
         else:
-            epoch = 'B4'
+            epoch = "B4"
     return epoch
 
+
 def convert_ccd_to_bindata_pix(pix_defs, bin_x, bin_y):
-    mod_pix_defs = [(pix_defs[0]-1)//bin_y,
-                    (pix_defs[1]-1)//bin_y,
-                    (pix_defs[2]-1)//bin_x,
-                    (pix_defs[3]-1)//bin_x]
+    mod_pix_defs = [
+        (pix_defs[0] - 1) // bin_y,
+        (pix_defs[1] - 1) // bin_y,
+        (pix_defs[2] - 1) // bin_x,
+        (pix_defs[3] - 1) // bin_x,
+    ]
     return mod_pix_defs
 
-def subtract_overscan(inimg, outimg,
-                      data_hdu = 0,
-                      detector_regions=None,
-                      overscan_regions=None,
-                      gain=None,
-                      rdnoise=None):
+
+def subtract_overscan(
+    inimg,
+    outimg,
+    data_hdu=0,
+    detector_regions=None,
+    overscan_regions=None,
+    gain=None,
+    rdnoise=None,
+):
     # (0) open file, initialize HDUList that will be saved at output
     f = pyfits.open(inimg)
     outfits = pyfits.HDUList(f)
@@ -664,100 +725,101 @@ def subtract_overscan(inimg, outimg,
     f.close()
     # (1) format detector and overscan regions
     #     - if 'None' grab default values
-    ccdsum = orig_hdr['CCDSUM']
+    ccdsum = orig_hdr["CCDSUM"]
     bins = ccdsum.split()
     bin_x = int(float(bins[0]))
     bin_y = int(float(bins[1]))
     # default values if all of the values are not specified
-    if ((detector_regions == None) or
-        (overscan_regions == None) or
-        (gain == None) or
-        (rdnoise == None)):
+    if (
+        (detector_regions == None)
+        or (overscan_regions == None)
+        or (gain == None)
+        or (rdnoise == None)
+    ):
         # determine the epoch
         epoch = determine_detector_epoch(inimg)
         # get detector characteristics
-        init_det_reg = default_detector_values[epoch]['det_regs']
-        detector_regions = [convert_ccd_to_bindata_pix(x, bin_x, bin_y)
-                            for x in init_det_reg]
-        init_ovs_reg = default_detector_values[epoch]['ovs_regs']
-        overscan_regions = [convert_ccd_to_bindata_pix(x, bin_x, bin_y)
-                            for x in init_ovs_reg]
-        init_sci_reg = default_detector_values[epoch]['sci_regs']
-        science_regions = [convert_ccd_to_bindata_pix(x, bin_x, bin_y)
-                           for x in init_sci_reg]
-        gain = default_detector_values[epoch]['gain']
-        rdnoise = default_detector_values[epoch]['rdnoise']
+        init_det_reg = default_detector_values[epoch]["det_regs"]
+        detector_regions = [
+            convert_ccd_to_bindata_pix(x, bin_x, bin_y) for x in init_det_reg
+        ]
+        init_ovs_reg = default_detector_values[epoch]["ovs_regs"]
+        overscan_regions = [
+            convert_ccd_to_bindata_pix(x, bin_x, bin_y) for x in init_ovs_reg
+        ]
+        init_sci_reg = default_detector_values[epoch]["sci_regs"]
+        science_regions = [
+            convert_ccd_to_bindata_pix(x, bin_x, bin_y) for x in init_sci_reg
+        ]
+        gain = default_detector_values[epoch]["gain"]
+        rdnoise = default_detector_values[epoch]["rdnoise"]
     # FORMAT REGION DEFINITIONS
-    fmt_det_reg = [[x[0],(x[1]+1),x[2],(x[3]+1)]
-                   for x in detector_regions]
-    fmt_ovs_reg = [[x[0],(x[1]+1),x[2],(x[3]+1)]
-                   for x in overscan_regions]
-    fmt_sci_reg = [[x[0],(x[1]+1),x[2],(x[3]+1)]
-                   for x in science_regions]
+    fmt_det_reg = [[x[0], (x[1] + 1), x[2], (x[3] + 1)] for x in detector_regions]
+    fmt_ovs_reg = [[x[0], (x[1] + 1), x[2], (x[3] + 1)] for x in overscan_regions]
+    fmt_sci_reg = [[x[0], (x[1] + 1), x[2], (x[3] + 1)] for x in science_regions]
     # (2) create data array - MUST QUERY FOR HALF-FRAME
     halfframe = is_halfframe(inimg, data_hdu=data_hdu)
     if halfframe:
-        ny = 2048//bin_y
-        nx = 4096//bin_x
+        ny = 2048 // bin_y
+        nx = 4096 // bin_x
         # note: offset will be equal to ny
-        subbed_data = numpy.zeros([ny,nx], dtype=float)
+        subbed_data = numpy.zeros([ny, nx], dtype=float)
         for i in range(len(fmt_det_reg)):
             init_det = fmt_det_reg[i]
-            det = [init_det[0], init_det[1]-ny, init_det[2], init_det[3]]
+            det = [init_det[0], init_det[1] - ny, init_det[2], init_det[3]]
             init_ovs = fmt_ovs_reg[i]
-            ovs = [init_ovs[0], init_ovs[1]-ny, init_ovs[2], init_ovs[3]]
+            ovs = [init_ovs[0], init_ovs[1] - ny, init_ovs[2], init_ovs[3]]
             init_sci = fmt_sci_reg[i]
-            sci = [init_sci[0], init_sci[1]-ny, init_sci[2], init_sci[3]]
-            curr_data = (
-                orig_data[det[0]:det[1],det[2]:det[3]])
+            sci = [init_sci[0], init_sci[1] - ny, init_sci[2], init_sci[3]]
+            curr_data = orig_data[det[0] : det[1], det[2] : det[3]]
             # (3) create mean/median overscan, subtract from data
-            curr_ovs_data = orig_data[ovs[0]:ovs[1],ovs[2]:ovs[3]]
+            curr_ovs_data = orig_data[ovs[0] : ovs[1], ovs[2] : ovs[3]]
             curr_ovs_val = numpy.median(curr_ovs_data)
-            subbed_data[sci[0]:sci[1],sci[2]:sci[3]] = (
-                gain[i]*(curr_data-curr_ovs_val))
+            subbed_data[sci[0] : sci[1], sci[2] : sci[3]] = gain[i] * (
+                curr_data - curr_ovs_val
+            )
     else:
-        ny = 4096//bin_y
-        nx = 4096//bin_x
-        subbed_data = numpy.zeros([ny,nx], dtype=float)
+        ny = 4096 // bin_y
+        nx = 4096 // bin_x
+        subbed_data = numpy.zeros([ny, nx], dtype=float)
         for i in range(len(fmt_det_reg)):
             det = fmt_det_reg[i]
             ovs = fmt_ovs_reg[i]
             sci = fmt_sci_reg[i]
-            curr_data = (
-                orig_data[det[0]:det[1],det[2]:det[3]])
+            curr_data = orig_data[det[0] : det[1], det[2] : det[3]]
             # (3) create mean/median overscan, subtract from data
-            curr_ovs_data = orig_data[ovs[0]:ovs[1],ovs[2]:ovs[3]]
+            curr_ovs_data = orig_data[ovs[0] : ovs[1], ovs[2] : ovs[3]]
             curr_ovs_val = numpy.median(curr_ovs_data)
-            subbed_data[sci[0]:sci[1],sci[2]:sci[3]] = (
-                gain[i]*(curr_data-curr_ovs_val))
+            subbed_data[sci[0] : sci[1], sci[2] : sci[3]] = gain[i] * (
+                curr_data - curr_ovs_val
+            )
     # (3b) - if epoch R4a, flip data!
-    if epoch == 'R4a':
-        temp_data = subbed_data[:,::-1]
-        next_data = temp_data[::-1,:]
+    if epoch == "R4a":
+        temp_data = subbed_data[:, ::-1]
+        next_data = temp_data[::-1, :]
         subbed_data = next_data
     # (4) only modify data part of data_hdu for output
-    detsize_str = '[%d:%d,%d:%d]' % (1, ny, 1, nx)
-    outfits[data_hdu].header.set('DETSIZE', detsize_str)
-    outfits[data_hdu].header.set('CCDSIZE', detsize_str)
-    #outfits[data_hdu].header.set('DETSEC',  detsize_str)
-    outfits[data_hdu].header.set('DATASEC', detsize_str)
-    outfits[data_hdu].header.set('TRIMSEC', detsize_str)
-    outfits[data_hdu].header.set('RDNOISE', max(rdnoise))
-    outfits[data_hdu].header.set('GAIN', 1.0)
-    outfits[data_hdu].header.set('PYWIFES', __version__, 'PyWiFeS version')
+    detsize_str = "[%d:%d,%d:%d]" % (1, ny, 1, nx)
+    outfits[data_hdu].header.set("DETSIZE", detsize_str)
+    outfits[data_hdu].header.set("CCDSIZE", detsize_str)
+    # outfits[data_hdu].header.set('DETSEC',  detsize_str)
+    outfits[data_hdu].header.set("DATASEC", detsize_str)
+    outfits[data_hdu].header.set("TRIMSEC", detsize_str)
+    outfits[data_hdu].header.set("RDNOISE", max(rdnoise))
+    outfits[data_hdu].header.set("GAIN", 1.0)
+    outfits[data_hdu].header.set("PYWIFES", __version__, "PyWiFeS version")
     outfits[data_hdu].data = subbed_data
     # (5) write to outfile!
     outfits.writeto(outimg, overwrite=True)
     return
 
-#------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------
 # NEW 2013-06-06
-def repair_blue_bad_pix(inimg, outimg,
-                        data_hdu=0,
-                        bin_x=1, bin_y=1):
+def repair_blue_bad_pix(inimg, outimg, data_hdu=0, bin_x=1, bin_y=1):
     # first check it is the new blue detector, otherwise skip
     epoch = determine_detector_epoch(inimg)
-    if epoch[0] != 'B' or float(epoch[1]) < 4:
+    if epoch[0] != "B" or float(epoch[1]) < 4:
         imcopy(inimg, outimg)
         return
     # get data and header
@@ -767,7 +829,7 @@ def repair_blue_bad_pix(inimg, outimg,
     orig_hdr = f[data_hdu].header
     f.close()
     # figure out binning
-    ccdsum = orig_hdr['CCDSUM']
+    ccdsum = orig_hdr["CCDSUM"]
     bins = ccdsum.split()
     bin_x = int(float(bins[0]))
     bin_y = int(float(bins[1]))
@@ -775,26 +837,26 @@ def repair_blue_bad_pix(inimg, outimg,
     halfframe = is_halfframe(inimg)
     if halfframe:
         y_bad_min = 0
-        y_bad_max = 2048//bin_y
+        y_bad_max = 2048 // bin_y
     else:
-        y_bad_min = 752//bin_y-1
-        y_bad_max = 4096//bin_y
-    x_bad = 1529//bin_x-1
-    interp_data = 1.0*orig_data
+        y_bad_min = 752 // bin_y - 1
+        y_bad_max = 4096 // bin_y
+    x_bad = 1529 // bin_x - 1
+    interp_data = 1.0 * orig_data
     for i in range(y_bad_min, y_bad_max):
-        interp_data[i,x_bad] = 0.5*(interp_data[i,x_bad-1]+
-                                    interp_data[i,x_bad+1])
+        interp_data[i, x_bad] = 0.5 * (
+            interp_data[i, x_bad - 1] + interp_data[i, x_bad + 1]
+        )
     # save it!
     outfits[data_hdu].data = interp_data
     outfits.writeto(outimg, overwrite=True)
     return
 
-def repair_red_bad_pix(inimg, outimg,
-                       data_hdu=0,
-                       bin_x=1, bin_y=1):
+
+def repair_red_bad_pix(inimg, outimg, data_hdu=0, bin_x=1, bin_y=1):
     # first check it is the new blue detector, otherwise skip
     epoch = determine_detector_epoch(inimg)
-    if epoch[0] != 'R' or float(epoch[1]) < 4:
+    if epoch[0] != "R" or float(epoch[1]) < 4:
         imcopy(inimg, outimg)
         return
     # get data and header
@@ -804,42 +866,47 @@ def repair_red_bad_pix(inimg, outimg,
     orig_hdr = f[data_hdu].header
     f.close()
     # figure out binning
-    ccdsum = orig_hdr['CCDSUM']
+    ccdsum = orig_hdr["CCDSUM"]
     bins = ccdsum.split()
     bin_x = int(float(bins[0]))
     bin_y = int(float(bins[1]))
     # now interpolate
     halfframe = is_halfframe(inimg)
     if halfframe:
-        y_bad_min = (3242-2048)//bin_y-1
-        y_bad_max = 2048//bin_y
+        y_bad_min = (3242 - 2048) // bin_y - 1
+        y_bad_max = 2048 // bin_y
     else:
-        y_bad_min = 3282//bin_y-1
-        y_bad_max = 4096//bin_y
-    x_bad_1 = 774//bin_x-1
-    x_bad_2 = 775//bin_x-1
-    interp_data = 1.0*orig_data
+        y_bad_min = 3282 // bin_y - 1
+        y_bad_max = 4096 // bin_y
+    x_bad_1 = 774 // bin_x - 1
+    x_bad_2 = 775 // bin_x - 1
+    interp_data = 1.0 * orig_data
     for i in range(y_bad_min, y_bad_max):
-        interp_data[i,x_bad_1] = (2.0*interp_data[i,x_bad_1-1]+
-                                  1.0*interp_data[i,x_bad_2+1])/3.0
-        interp_data[i,x_bad_2] = (1.0*interp_data[i,x_bad_1-1]+
-                                  2.0*interp_data[i,x_bad_2+1])/3.0
+        interp_data[i, x_bad_1] = (
+            2.0 * interp_data[i, x_bad_1 - 1] + 1.0 * interp_data[i, x_bad_2 + 1]
+        ) / 3.0
+        interp_data[i, x_bad_2] = (
+            1.0 * interp_data[i, x_bad_1 - 1] + 2.0 * interp_data[i, x_bad_2 + 1]
+        ) / 3.0
     # save it!
     outfits[data_hdu].data = interp_data
     outfits.writeto(outimg, overwrite=True)
     return
 
-#------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------
 # NEW 2012-11-08
 # inter-slitlet bias subtraction method
-def fit_wifes_interslit_bias(inimg,
-                             data_hdu=0,
-                             slitlet_def_file=None,
-                             method='row_med',
-                             x_polydeg=1,
-                             y_polydeg=1,
-                             plot=False):
-    #---------------------------
+def fit_wifes_interslit_bias(
+    inimg,
+    data_hdu=0,
+    slitlet_def_file=None,
+    method="row_med",
+    x_polydeg=1,
+    y_polydeg=1,
+    plot=False,
+):
+    # ---------------------------
     # (0) open file, initialize HDUList that will be saved at output
     f = pyfits.open(inimg)
     outfits = pyfits.HDUList(f)
@@ -849,131 +916,137 @@ def fit_wifes_interslit_bias(inimg,
     # check if halfframe
     halfframe = is_halfframe(inimg)
     # grab necessary info from header
-    ccdsum = orig_hdr['CCDSUM']
+    ccdsum = orig_hdr["CCDSUM"]
     bins = ccdsum.split()
     bin_x = int(float(bins[0]))
     bin_y = int(float(bins[1]))
-    utc_str = orig_hdr['DATE-OBS'].split('T')[0]
-    utc_date = int(float(utc_str.replace('-','')))
-    camera = orig_hdr['CAMERA']
-    #---------------------------
+    utc_str = orig_hdr["DATE-OBS"].split("T")[0]
+    utc_date = int(float(utc_str.replace("-", "")))
+    camera = orig_hdr["CAMERA"]
+    # ---------------------------
     # (1) make a mask of inter-slitlet zones
     interstice_map = numpy.ones(numpy.shape(orig_data))
     interstice_mask = numpy.ones(numpy.shape(orig_data)[0])
     if slitlet_def_file != None:
-        f2 = open(slitlet_def_file, 'rb')
+        f2 = open(slitlet_def_file, "rb")
         slitlet_defs = pickle.load(f2)
         f2.close()
-    elif camera == 'WiFeSRed':
+    elif camera == "WiFeSRed":
         slitlet_defs = red_slitlet_defs
     else:
         slitlet_defs = blue_slitlet_defs
     if halfframe:
         nslits = 12
-        offset = 4096//bin_y
+        offset = 4096 // bin_y
     else:
         nslits = 25
         offset = 0
     for i in range(nslits):
-        init_curr_defs = slitlet_defs[str(i+1)]
+        init_curr_defs = slitlet_defs[str(i + 1)]
         # convert to binned values
         curr_defs = [
-            ((init_curr_defs[0]-1)//bin_x)+1,
-            ((init_curr_defs[1]-1)//bin_x)+1,
-            ((init_curr_defs[2]-1)//bin_y)+1,
-            ((init_curr_defs[3]-1)//bin_y)+1]
+            ((init_curr_defs[0] - 1) // bin_x) + 1,
+            ((init_curr_defs[1] - 1) // bin_x) + 1,
+            ((init_curr_defs[2] - 1) // bin_y) + 1,
+            ((init_curr_defs[3] - 1) // bin_y) + 1,
+        ]
         # horrible kluge to make sure everything has the same dimensions!
-        if (curr_defs[1]-curr_defs[0]+1) != (4096//bin_x):
+        if (curr_defs[1] - curr_defs[0] + 1) != (4096 // bin_x):
             curr_defs[1] -= 1
-        if (curr_defs[3]-curr_defs[2]+1) != (86//bin_y):
+        if (curr_defs[3] - curr_defs[2] + 1) != (86 // bin_y):
             curr_defs[3] -= 1
         # define a buffer zone
-        ybuff=6//bin_y
-        mod_defs = [curr_defs[0]-1, curr_defs[1],
-                    curr_defs[2]-1-ybuff-offset,
-                    curr_defs[3]+ybuff-offset]
+        ybuff = 6 // bin_y
+        mod_defs = [
+            curr_defs[0] - 1,
+            curr_defs[1],
+            curr_defs[2] - 1 - ybuff - offset,
+            curr_defs[3] + ybuff - offset,
+        ]
         # everything in slitlet zone gets set to zero
-        interstice_map[mod_defs[2]:mod_defs[3],
-                       mod_defs[0]:mod_defs[1]] = 0
-        interstice_mask[mod_defs[2]:mod_defs[3]] = 0
-    #---------------------------
+        interstice_map[mod_defs[2] : mod_defs[3], mod_defs[0] : mod_defs[1]] = 0
+        interstice_mask[mod_defs[2] : mod_defs[3]] = 0
+    # ---------------------------
     # (2) from its epoch, determine if is 1-amp or 4-amp readout
-    if camera == 'WiFeSRed':
+    if camera == "WiFeSRed":
         if utc_date < 20110616:
             # namps=4
-            sci_regs = [[0,2047//bin_y,0,2047//bin_x],
-                        [0,2047//bin_y,2048//bin_x,4095//bin_x],
-                        [2048//bin_y,4095//bin_y,0,2047//bin_x],
-                        [2048//bin_y,4095//bin_y,2048//bin_x,4095//bin_x]]
+            sci_regs = [
+                [0, 2047 // bin_y, 0, 2047 // bin_x],
+                [0, 2047 // bin_y, 2048 // bin_x, 4095 // bin_x],
+                [2048 // bin_y, 4095 // bin_y, 0, 2047 // bin_x],
+                [2048 // bin_y, 4095 // bin_y, 2048 // bin_x, 4095 // bin_x],
+            ]
         else:
             # namps=1
-            sci_regs = [[0,4095//bin_y,0,4095//bin_x]]
+            sci_regs = [[0, 4095 // bin_y, 0, 4095 // bin_x]]
     else:
         if utc_date < 20100801:
             # namps=4
-            sci_regs = [[0,2047//bin_y,0,2047//bin_x],
-                        [0,2047//bin_y,2048//bin_x,4095//bin_x],
-                        [2048//bin_y,4095//bin_y,0,2047//bin_x],
-                        [2048//bin_y,4095//bin_y,2048//bin_x,4095//bin_x]]
+            sci_regs = [
+                [0, 2047 // bin_y, 0, 2047 // bin_x],
+                [0, 2047 // bin_y, 2048 // bin_x, 4095 // bin_x],
+                [2048 // bin_y, 4095 // bin_y, 0, 2047 // bin_x],
+                [2048 // bin_y, 4095 // bin_y, 2048 // bin_x, 4095 // bin_x],
+            ]
         else:
             # namps=1
-            sci_regs = [[0,4095//bin_y,0,4095//bin_x]]
-    #---------------------------
+            sci_regs = [[0, 4095 // bin_y, 0, 4095 // bin_x]]
+    # ---------------------------
     # (3) for each sci region, get interstitial bias level
-    out_data = numpy.zeros(numpy.shape(orig_data), dtype='d')
+    out_data = numpy.zeros(numpy.shape(orig_data), dtype="d")
     for i in range(len(sci_regs)):
         init_reg = sci_regs[i]
         if halfframe:
-            ny = 2048//bin_y
-            reg = [init_reg[0], init_reg[1]-ny, init_reg[2], init_reg[3]]
+            ny = 2048 // bin_y
+            reg = [init_reg[0], init_reg[1] - ny, init_reg[2], init_reg[3]]
         else:
             reg = init_reg
-        curr_data = orig_data[reg[0]:reg[1]+1,reg[2]:reg[3]+1]
-        curr_map  = interstice_map[reg[0]:reg[1]+1,reg[2]:reg[3]+1]
-        curr_mask = interstice_mask[reg[0]:reg[1]+1]
+        curr_data = orig_data[reg[0] : reg[1] + 1, reg[2] : reg[3] + 1]
+        curr_map = interstice_map[reg[0] : reg[1] + 1, reg[2] : reg[3] + 1]
+        curr_mask = interstice_mask[reg[0] : reg[1] + 1]
         ny, nx = numpy.shape(curr_data)
-        linx = numpy.arange(nx, dtype='d')
-        liny = numpy.arange(ny, dtype='d')
-        full_x, full_y = numpy.meshgrid(linx, liny)        
-        if method == 'row_med':
-            #ny, nx = numpy.shape(curr_data)
-            row_med = numpy.zeros(nx, dtype='d')
+        linx = numpy.arange(nx, dtype="d")
+        liny = numpy.arange(ny, dtype="d")
+        full_x, full_y = numpy.meshgrid(linx, liny)
+        if method == "row_med":
+            # ny, nx = numpy.shape(curr_data)
+            row_med = numpy.zeros(nx, dtype="d")
             # iterate over columns to excise CRs... bleh
             for i in range(nx):
-                curr_col = curr_data[:,i]
-                curr_med = numpy.median(curr_col[
-                    numpy.nonzero(curr_mask)[0]])
+                curr_col = curr_data[:, i]
+                curr_med = numpy.median(curr_col[numpy.nonzero(curr_mask)[0]])
                 good_inds = numpy.nonzero(
-                    (numpy.abs(curr_col - curr_med) < 20.0)*
-                    (curr_mask))[0]
+                    (numpy.abs(curr_col - curr_med) < 20.0) * (curr_mask)
+                )[0]
                 pylab.figure()
                 pylab.hist(curr_col[good_inds], bins=50)
                 pylab.show()
                 row_med[i] = numpy.mean(curr_col[good_inds])
-            #row_med = numpy.median(curr_data, axis=0)
-            bias_sub = row_med**numpy.ones(
-                numpy.shape(curr_data), dtype='d')
-            out_data[reg[0]:reg[1]+1,reg[2]:reg[3]+1] = bias_sub
-        elif method == 'surface':
+            # row_med = numpy.median(curr_data, axis=0)
+            bias_sub = row_med ** numpy.ones(numpy.shape(curr_data), dtype="d")
+            out_data[reg[0] : reg[1] + 1, reg[2] : reg[3] + 1] = bias_sub
+        elif method == "surface":
             curr_inds = numpy.nonzero(curr_map)
             fit_x = full_x[curr_inds].flatten()
             fit_y = full_y[curr_inds].flatten()
             fit_b = curr_data[curr_inds].flatten()
-            init_x_poly, init_y_poly = fit_wsol_poly(fit_x, fit_y, fit_b,
-                                                     x_polydeg, y_polydeg)
-            init_bias_fvals = evaluate_wsol_poly(
-                fit_x, fit_y, init_x_poly, init_y_poly)
+            init_x_poly, init_y_poly = fit_wsol_poly(
+                fit_x, fit_y, fit_b, x_polydeg, y_polydeg
+            )
+            init_bias_fvals = evaluate_wsol_poly(fit_x, fit_y, init_x_poly, init_y_poly)
             resids = fit_b - init_bias_fvals
-            resids_rms = numpy.median(resids**2)**0.5
-            good_inds = numpy.nonzero(numpy.abs(resids) <
-                                      3.0*(resids_rms))
-            x_poly, y_poly = fit_wsol_poly(fit_x[good_inds],
-                                           fit_y[good_inds],
-                                           fit_b[good_inds],
-                                           x_polydeg, y_polydeg)
-            bias_fvals = evaluate_wsol_poly(
-                full_x, full_y, x_poly, y_poly)
-            out_data[reg[0]:reg[1]+1,reg[2]:reg[3]+1] = bias_fvals
+            resids_rms = numpy.median(resids**2) ** 0.5
+            good_inds = numpy.nonzero(numpy.abs(resids) < 3.0 * (resids_rms))
+            x_poly, y_poly = fit_wsol_poly(
+                fit_x[good_inds],
+                fit_y[good_inds],
+                fit_b[good_inds],
+                x_polydeg,
+                y_polydeg,
+            )
+            bias_fvals = evaluate_wsol_poly(full_x, full_y, x_poly, y_poly)
+            out_data[reg[0] : reg[1] + 1, reg[2] : reg[3] + 1] = bias_fvals
             # PLOT IT!!!
             if plot:
                 randplot_data = numpy.random.permutation(len(fit_x))[:1000]
@@ -981,283 +1054,352 @@ def fit_wifes_interslit_bias(inimg,
                 randplot_lin_mask = numpy.zeros(len(full_x.flatten()))
                 randplot_lin_mask[randplot_inds] = 1
                 randplot_mask = numpy.reshape(randplot_lin_mask, numpy.shape(full_x))
-                randplot_fit  = numpy.nonzero(randplot_mask)
+                randplot_fit = numpy.nonzero(randplot_mask)
                 fig = pylab.figure()
-                sp = fig.gca(projection='3d')
-                sp.plot(fit_x[randplot_data],
-                        fit_y[randplot_data],
-                        fit_b[randplot_data], 'b.')
-                sp.plot_surface(full_x,
-                                full_y,
-                                bias_fvals,
-                                alpha=0.3, rstride=200, cstride=200, color='r')
+                sp = fig.gca(projection="3d")
+                sp.plot(
+                    fit_x[randplot_data],
+                    fit_y[randplot_data],
+                    fit_b[randplot_data],
+                    "b.",
+                )
+                sp.plot_surface(
+                    full_x,
+                    full_y,
+                    bias_fvals,
+                    alpha=0.3,
+                    rstride=200,
+                    cstride=200,
+                    color="r",
+                )
                 fval_med = numpy.median(bias_fvals)
-                sp.set_zlim([fval_med-5.0*resids_rms,
-                             fval_med+5.0*resids_rms])
+                sp.set_zlim([fval_med - 5.0 * resids_rms, fval_med + 5.0 * resids_rms])
                 pylab.show()
-        elif method == 'median':
+        elif method == "median":
             bias_val = numpy.median(curr_data[numpy.nonzero(curr_map)])
-            out_data[reg[0]:reg[1]+1,reg[2]:reg[3]+1] = bias_val
+            out_data[reg[0] : reg[1] + 1, reg[2] : reg[3] + 1] = bias_val
         else:
-            print('only row_med and median methods currently supported')
-    #---------------------------
+            print("only row_med and median methods currently supported")
+    # ---------------------------
     # (4) return it!
     return out_data
     return
 
-def save_wifes_interslit_bias(inimg, outimg,
-                              data_hdu=0,
-                              slitlet_def_file=None,
-                              method='surface',
-                              x_polydeg=1,
-                              y_polydeg=1,
-                              plot=False):
+
+def save_wifes_interslit_bias(
+    inimg,
+    outimg,
+    data_hdu=0,
+    slitlet_def_file=None,
+    method="surface",
+    x_polydeg=1,
+    y_polydeg=1,
+    plot=False,
+):
     # (0) open file, initialize HDUList that will be saved at output
     f = pyfits.open(inimg)
     outfits = pyfits.HDUList(f)
     # (1) fit bias with requested settings
-    out_data = fit_wifes_interslit_bias(inimg,
-                                        data_hdu=data_hdu,
-                                        slitlet_def_file=slitlet_def_file,
-                                        method=method,
-                                        x_polydeg=x_polydeg,
-                                        y_polydeg=y_polydeg,
-                                        plot=plot)
+    out_data = fit_wifes_interslit_bias(
+        inimg,
+        data_hdu=data_hdu,
+        slitlet_def_file=slitlet_def_file,
+        method=method,
+        x_polydeg=x_polydeg,
+        y_polydeg=y_polydeg,
+        plot=plot,
+    )
     # (2) save it!
     outfits[data_hdu].data = out_data
-    outfits[data_hdu].header.set('PYWIFES', __version__, 'PyWiFeS version')
+    outfits[data_hdu].header.set("PYWIFES", __version__, "PyWiFeS version")
     outfits.writeto(outimg, overwrite=True)
     f.close()
     return
 
-def subtract_wifes_interslit_bias(inimg, outimg,
-                                  data_hdu=0,
-                                  slitlet_def_file=None,
-                                  method='surface',
-                                  x_polydeg=1,
-                                  y_polydeg=1,
-                                  plot=False):
+
+def subtract_wifes_interslit_bias(
+    inimg,
+    outimg,
+    data_hdu=0,
+    slitlet_def_file=None,
+    method="surface",
+    x_polydeg=1,
+    y_polydeg=1,
+    plot=False,
+):
     # (0) open file, initialize HDUList that will be saved at output
     f = pyfits.open(inimg)
     outfits = pyfits.HDUList(f)
     orig_data = f[data_hdu].data
     # (1) fit bias with requested settings
-    out_data = fit_wifes_interslit_bias(inimg,
-                                        data_hdu=data_hdu,
-                                        slitlet_def_file=slitlet_def_file,
-                                        method=method,
-                                        x_polydeg=x_polydeg,
-                                        y_polydeg=y_polydeg,
-                                        plot=plot)
+    out_data = fit_wifes_interslit_bias(
+        inimg,
+        data_hdu=data_hdu,
+        slitlet_def_file=slitlet_def_file,
+        method=method,
+        x_polydeg=x_polydeg,
+        y_polydeg=y_polydeg,
+        plot=plot,
+    )
     # (2) save it!
     outfits[data_hdu].data = orig_data - out_data
-    outfits[data_hdu].header.set('PYWIFES', __version__, 'PyWiFeS version')
+    outfits[data_hdu].header.set("PYWIFES", __version__, "PyWiFeS version")
     outfits.writeto(outimg, overwrite=True)
     return
 
-#------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------
 # NEW 2012-10-02
 # bias subtraction method
 
-#--------------------------- Fred's update ------------------------------
-def wifes_bias_model (p,x,camera) :
-    if camera == 'WiFeSRed' :
+
+# --------------------------- Fred's update ------------------------------
+def wifes_bias_model(p, x, camera):
+    if camera == "WiFeSRed":
         model = p[0]
-        model += p[1] * numpy.exp(p[2]/numpy.abs(x-p[3]) )
-        model += p[4] * numpy.exp(p[5]/numpy.abs(x-p[6]) )
+        model += p[1] * numpy.exp(p[2] / numpy.abs(x - p[3]))
+        model += p[4] * numpy.exp(p[5] / numpy.abs(x - p[6]))
         model += p[7] * x
-    else :
+    else:
         model = p[0]
-        model += p[1] * numpy.exp(p[2]/numpy.abs(x-p[3]) )
-        model += p[4] * numpy.exp(p[5]/numpy.abs(x-p[6]) )
+        model += p[1] * numpy.exp(p[2] / numpy.abs(x - p[3]))
+        model += p[4] * numpy.exp(p[5] / numpy.abs(x - p[6]))
         model += p[7] * x
-        model += p[8]* numpy.exp(-(p[9]*(x-p[10]))**2)
+        model += p[8] * numpy.exp(-((p[9] * (x - p[10])) ** 2))
     return model
 
-#--------------------------- Fred's update ------------------------------
-def error_wifes_bias_model (p,x,z,err,camera, fjac=None) :
-    status = 0
-    residual = (wifes_bias_model(p,x,camera) - z)/err
-    return ([status,residual])
 
-#--------------------------- Fred's update ------------------------------
-def generate_wifes_bias_fit(bias_img, outimg, data_hdu=0,
-                            plot=False, verbose=False, method = 'row_med'):
+# --------------------------- Fred's update ------------------------------
+def error_wifes_bias_model(p, x, z, err, camera, fjac=None):
+    status = 0
+    residual = (wifes_bias_model(p, x, camera) - z) / err
+    return [status, residual]
+
+
+# --------------------------- Fred's update ------------------------------
+def generate_wifes_bias_fit(
+    bias_img, outimg, data_hdu=0, plot=False, verbose=False, method="row_med"
+):
     # get object and bias data
     f1 = pyfits.open(bias_img)
     orig_data = f1[data_hdu].data
-    orig_hdr  = f1[data_hdu].header
+    orig_hdr = f1[data_hdu].header
     # from its epoch, determine if is 1-amp or 4-amp readout
-    ccdsum = orig_hdr['CCDSUM']
+    ccdsum = orig_hdr["CCDSUM"]
     bins = ccdsum.split()
     bin_x = int(float(bins[0]))
     bin_y = int(float(bins[1]))
-    utc_str = orig_hdr['DATE-OBS'].split('T')[0]
-    utc_date = int(float(utc_str.replace('-','')))
-    camera = orig_hdr['CAMERA']
-    if camera == 'WiFeSRed':
+    utc_str = orig_hdr["DATE-OBS"].split("T")[0]
+    utc_date = int(float(utc_str.replace("-", "")))
+    camera = orig_hdr["CAMERA"]
+    if camera == "WiFeSRed":
         if utc_date < 20110616:
             # namps=4
-            sci_regs = [[0,2047//bin_y,0,2047//bin_x],
-                        [0,2047//bin_y,2048//bin_x,4095//bin_x],
-                        [2048//bin_y,4095//bin_y,0,2047//bin_x],
-                        [2048//bin_y,4095//bin_y,2048//bin_x,4095//bin_x]]
+            sci_regs = [
+                [0, 2047 // bin_y, 0, 2047 // bin_x],
+                [0, 2047 // bin_y, 2048 // bin_x, 4095 // bin_x],
+                [2048 // bin_y, 4095 // bin_y, 0, 2047 // bin_x],
+                [2048 // bin_y, 4095 // bin_y, 2048 // bin_x, 4095 // bin_x],
+            ]
             # Currently not supported !
-            if method == 'fit' :
-                print(' ---')
-                print('Bias frame not compatible with surface fitting (4 amps) !')
-                print(' --- ')
+            if method == "fit":
+                print(" ---")
+                print("Bias frame not compatible with surface fitting (4 amps) !")
+                print(" --- ")
         else:
             # namps=1
-            sci_regs = [[0,4095//bin_y,0,4095//bin_x]]
+            sci_regs = [[0, 4095 // bin_y, 0, 4095 // bin_x]]
     else:
         if utc_date < 20100801:
             # namps=4
-            sci_regs = [[0,2047//bin_y,0,2047//bin_x],
-                        [0,2047//bin_y,2048//bin_x,4095//bin_x],
-                        [2048//bin_y,4095//bin_y,0,2047//bin_x],
-                        [2048//bin_y,4095//bin_y,2048//bin_x,4095//bin_x]]
+            sci_regs = [
+                [0, 2047 // bin_y, 0, 2047 // bin_x],
+                [0, 2047 // bin_y, 2048 // bin_x, 4095 // bin_x],
+                [2048 // bin_y, 4095 // bin_y, 0, 2047 // bin_x],
+                [2048 // bin_y, 4095 // bin_y, 2048 // bin_x, 4095 // bin_x],
+            ]
             # Currently not supported !
-            if method == 'fit' :
-                print(' ---')
-                print('Bias frame not compatible with surface fitting (4 amps) !')
-                print(' --- ')
+            if method == "fit":
+                print(" ---")
+                print("Bias frame not compatible with surface fitting (4 amps) !")
+                print(" --- ")
 
         else:
             # namps=1
-            sci_regs = [[0,4095//bin_y,0,4095//bin_x]]
+            sci_regs = [[0, 4095 // bin_y, 0, 4095 // bin_x]]
 
     # method == fit :
     # for each region, fit the bias structure
-    # It is time consuming to fit the whole 2D structure of the bias. 
+    # It is time consuming to fit the whole 2D structure of the bias.
     # Instead, I collapse it along the y-direction and fit it.
-    # It's (much) faster, and accurate enough. 
+    # It's (much) faster, and accurate enough.
     # method == row_med :
     # This is faster still, and as accurate. No fitting required, we just collapsed
     # the bias, and take the mean after rejecting outliers. Should be the default,
     # unless you know what you are doing ...
 
-    out_data = numpy.zeros(numpy.shape(orig_data), dtype='d')
+    out_data = numpy.zeros(numpy.shape(orig_data), dtype="d")
     for i in range(len(sci_regs)):
         reg = sci_regs[i]
-        curr_data = orig_data[reg[0]:reg[1]+1,reg[2]:reg[3]+1]
-    
+        curr_data = orig_data[reg[0] : reg[1] + 1, reg[2] : reg[3] + 1]
+
         ny, nx = numpy.shape(curr_data)
-        linx = numpy.arange(nx, dtype='d')
-        liny = numpy.arange(ny, dtype='d')
+        linx = numpy.arange(nx, dtype="d")
+        liny = numpy.arange(ny, dtype="d")
         full_x, full_y = numpy.meshgrid(linx, liny)
 
-        if method == 'row_med':
-           #ny, nx = numpy.shape(curr_data)
-           row_med = numpy.zeros(nx, dtype='d')
-           # iterate over columns to excise CRs... bleh
-           for i in range(nx):
-               curr_col = curr_data[:,i]
-               curr_med = numpy.median(curr_col)
-               good_inds = numpy.nonzero(
-                   numpy.abs(curr_col - curr_med) < 20.0)[0]
-               row_med[i] = numpy.mean(curr_col[good_inds])
-           #row_med = numpy.median(curr_data, axis=0)
-           bias_sub = row_med**numpy.ones(
-               numpy.shape(curr_data), dtype='d')
-           # Fred's update (bias fit) ------
-           # To remove the variations (some at least) along the 
-           # y-direction, let's smooth the residuals !
-           residual = curr_data - bias_sub
-           residual[numpy.where(residual>150)]=0.0 # remove 'CR'
-           residual_blur = ndimage.gaussian_filter(residual,sigma=[50,50])
-           bias_sub += residual_blur
-           # -----
-           out_data[reg[0]:reg[1]+1,reg[2]:reg[3]+1] = bias_sub
+        if method == "row_med":
+            # ny, nx = numpy.shape(curr_data)
+            row_med = numpy.zeros(nx, dtype="d")
+            # iterate over columns to excise CRs... bleh
+            for i in range(nx):
+                curr_col = curr_data[:, i]
+                curr_med = numpy.median(curr_col)
+                good_inds = numpy.nonzero(numpy.abs(curr_col - curr_med) < 20.0)[0]
+                row_med[i] = numpy.mean(curr_col[good_inds])
+            # row_med = numpy.median(curr_data, axis=0)
+            bias_sub = row_med ** numpy.ones(numpy.shape(curr_data), dtype="d")
+            # Fred's update (bias fit) ------
+            # To remove the variations (some at least) along the
+            # y-direction, let's smooth the residuals !
+            residual = curr_data - bias_sub
+            residual[numpy.where(residual > 150)] = 0.0  # remove 'CR'
+            residual_blur = ndimage.gaussian_filter(residual, sigma=[50, 50])
+            bias_sub += residual_blur
+            # -----
+            out_data[reg[0] : reg[1] + 1, reg[2] : reg[3] + 1] = bias_sub
 
-        if method == 'fit':
-        # Fit the bias with an appropriate model
-        # Initial conditions differ depending on the camera
+        if method == "fit":
+            # Fit the bias with an appropriate model
+            # Initial conditions differ depending on the camera
 
-            if camera == 'WiFeSRed' :
-                p0 = [0.,1., -200.,4100., 1., 20.,-800., 0.0001]
-                fa = {'x': linx, 'z':curr_data.mean(axis=0), 
-                      'err':curr_data.std(axis=0), 'camera':camera }
-                constraints = [{'limited':[0,0]},
-                               {'limited':[0,0]},
-                               {'limited':[0,0]},            
-                               {'limited':[1,0], 'limits':[numpy.max(full_x[0,:]),0]},
-                               {'limited':[0,0]},
-                               {'limited':[0,0]},
-                               {'limited':[0,1], 'limits':[0,numpy.min(full_x[0,:])]},
-                               {'limited':[0,0]}
-                               ]
+            if camera == "WiFeSRed":
+                p0 = [0.0, 1.0, -200.0, 4100.0, 1.0, 20.0, -800.0, 0.0001]
+                fa = {
+                    "x": linx,
+                    "z": curr_data.mean(axis=0),
+                    "err": curr_data.std(axis=0),
+                    "camera": camera,
+                }
+                constraints = [
+                    {"limited": [0, 0]},
+                    {"limited": [0, 0]},
+                    {"limited": [0, 0]},
+                    {"limited": [1, 0], "limits": [numpy.max(full_x[0, :]), 0]},
+                    {"limited": [0, 0]},
+                    {"limited": [0, 0]},
+                    {"limited": [0, 1], "limits": [0, numpy.min(full_x[0, :])]},
+                    {"limited": [0, 0]},
+                ]
 
-            else :
-                p0 = [-3.,5., -500.,4100., 0.0001, 200.,-800., 0.0001, 1, 0.01,4000.]
-                fa = {'x': linx, 'z':curr_data.mean(axis=0), 
-                      'err':curr_data.std(axis=0), 'camera':camera }
-                constraints = [{'limited':[0,0]},
-                               {'limited':[0,0]},
-                               {'limited':[0,0]},            
-                               {'limited':[1,0], 'limits':[numpy.max(full_x[0,:]),0]},
-                               {'limited':[0,0]},
-                               {'limited':[0,0]},
-                               {'limited':[0,1], 'limits':[0,numpy.min(full_x[0,:])]},
-                               {'limited':[0,0]},
-                               {'limited':[1,0], 'limits':[0,0]},
-                               {'limited':[0,0]},
-                               {'limited':[0,0]}
-                               ]
+            else:
+                p0 = [
+                    -3.0,
+                    5.0,
+                    -500.0,
+                    4100.0,
+                    0.0001,
+                    200.0,
+                    -800.0,
+                    0.0001,
+                    1,
+                    0.01,
+                    4000.0,
+                ]
+                fa = {
+                    "x": linx,
+                    "z": curr_data.mean(axis=0),
+                    "err": curr_data.std(axis=0),
+                    "camera": camera,
+                }
+                constraints = [
+                    {"limited": [0, 0]},
+                    {"limited": [0, 0]},
+                    {"limited": [0, 0]},
+                    {"limited": [1, 0], "limits": [numpy.max(full_x[0, :]), 0]},
+                    {"limited": [0, 0]},
+                    {"limited": [0, 0]},
+                    {"limited": [0, 1], "limits": [0, numpy.min(full_x[0, :])]},
+                    {"limited": [0, 0]},
+                    {"limited": [1, 0], "limits": [0, 0]},
+                    {"limited": [0, 0]},
+                    {"limited": [0, 0]},
+                ]
 
-            print(' Fitting bias frame %s' % bias_img.split('/')[-1])
-            fit_result = mpfit(error_wifes_bias_model, p0, functkw = fa, 
-                                     parinfo = constraints, quiet=not verbose) 
+            print(" Fitting bias frame %s" % bias_img.split("/")[-1])
+            fit_result = mpfit(
+                error_wifes_bias_model,
+                p0,
+                functkw=fa,
+                parinfo=constraints,
+                quiet=not verbose,
+            )
             p1 = fit_result.params
-            #print p1
-            if fit_result.status <= 0 or fit_result.status == 5  :
-                print(' Fit may have failed : mpfit status:',fit_result.status)
+            # print p1
+            if fit_result.status <= 0 or fit_result.status == 5:
+                print(" Fit may have failed : mpfit status:", fit_result.status)
                 print("I'll plot this one for sanity check...")
                 plot = True
-    
-            out_data[reg[0]:reg[1]+1,reg[2]:reg[3]+1] = wifes_bias_model(p1,full_x,
-                                                                         camera)
+
+            out_data[reg[0] : reg[1] + 1, reg[2] : reg[3] + 1] = wifes_bias_model(
+                p1, full_x, camera
+            )
         # Plot for test purposes ...
         if plot:
             plt.figure()
-            plt.plot(linx, curr_data.mean(axis=0), 'k-', label='raw bias', lw=2)
-            if method == 'row_med':
-                plt.plot(linx, out_data.mean(axis=0),'r-', label = 'row_med bias')
-                plt.plot(linx, curr_data.mean(axis=0) - out_data.mean(axis=0), 'g-', label='residual')       
-            if method == 'fit' :
-                plt.plot(linx, curr_data.mean(axis=0) - wifes_bias_model(p1, linx, camera), 'g', label='residual')
-                plt.plot(linx, wifes_bias_model(p1, linx, camera), 'r', label='model fit')
+            plt.plot(linx, curr_data.mean(axis=0), "k-", label="raw bias", lw=2)
+            if method == "row_med":
+                plt.plot(linx, out_data.mean(axis=0), "r-", label="row_med bias")
+                plt.plot(
+                    linx,
+                    curr_data.mean(axis=0) - out_data.mean(axis=0),
+                    "g-",
+                    label="residual",
+                )
+            if method == "fit":
+                plt.plot(
+                    linx,
+                    curr_data.mean(axis=0) - wifes_bias_model(p1, linx, camera),
+                    "g",
+                    label="residual",
+                )
+                plt.plot(
+                    linx, wifes_bias_model(p1, linx, camera), "r", label="model fit"
+                )
 
-            plt.axhline(0, numpy.min(linx), numpy.max(linx), color='k')
-            plt.xlabel('x [pixels]')
-            plt.ylabel(' bias signal collapsed along y')
-            plt.legend(loc='lower left', fancybox=True, shadow=True)
+            plt.axhline(0, numpy.min(linx), numpy.max(linx), color="k")
+            plt.xlabel("x [pixels]")
+            plt.ylabel(" bias signal collapsed along y")
+            plt.legend(loc="lower left", fancybox=True, shadow=True)
             plt.xlim([numpy.min(linx), numpy.max(linx)])
             plt.ylim([-10, 10])
-            plt.title('Fitting bias frame %s' % bias_img.split('/')[-1])
+            plt.title("Fitting bias frame %s" % bias_img.split("/")[-1])
             plt.show()
-    
+
         # ----------------------------------------------------
     # save it!
     outfits = pyfits.HDUList(f1)
     outfits[data_hdu].data = out_data
-    outfits[data_hdu].header.set('PYWIFES', __version__, 'PyWiFeS version')
+    outfits[data_hdu].header.set("PYWIFES", __version__, "PyWiFeS version")
     outfits.writeto(outimg, overwrite=True)
     f1.close()
     return
 
-#------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------
 # WIFES specific tasks
-def derive_slitlet_profiles(flatfield_fn,
-                            output_fn,
-                            data_hdu=0,
-                            verbose=False,
-                            shift_global=True,
-                            plot=False,
-                            bin_x=None,
-                            bin_y=None):
+def derive_slitlet_profiles(
+    flatfield_fn,
+    output_fn,
+    data_hdu=0,
+    verbose=False,
+    shift_global=True,
+    plot=False,
+    bin_x=None,
+    bin_y=None,
+):
     """
-    Description: 
+    Description:
     """
     f = pyfits.open(flatfield_fn)
     flat_data = f[data_hdu].data
@@ -1267,7 +1409,7 @@ def derive_slitlet_profiles(flatfield_fn,
     halfframe = is_halfframe(flatfield_fn)
     # check for binning, if not specified read from header
     try:
-        bin_temp = orig_hdr['CCDSUM'].split()
+        bin_temp = orig_hdr["CCDSUM"].split()
         default_bin_x = int(float(bin_temp[0]))
         default_bin_y = int(float(bin_temp[1]))
     except:
@@ -1278,7 +1420,7 @@ def derive_slitlet_profiles(flatfield_fn,
     if bin_y == None:
         bin_y = default_bin_y
     # first check which camera it is
-    if orig_hdr['CAMERA'] == 'WiFeSRed':
+    if orig_hdr["CAMERA"] == "WiFeSRed":
         baseline_defs = red_slitlet_defs
     else:
         baseline_defs = blue_slitlet_defs
@@ -1287,93 +1429,105 @@ def derive_slitlet_profiles(flatfield_fn,
     y_shift_vals = []
     if halfframe:
         nslits = 12
-        offset = 4096//bin_y
+        offset = 4096 // bin_y
     else:
         nslits = 25
         offset = 0
     for i in range(nslits):
-        init_curr_defs = baseline_defs[str(i+1)]
+        init_curr_defs = baseline_defs[str(i + 1)]
         # convert to binned values
         curr_defs = [
-            ((init_curr_defs[0]-1)//bin_x)+1,
-            ((init_curr_defs[1]-1)//bin_x)+1,
-            ((init_curr_defs[2]-1)//bin_y)+1,
-            ((init_curr_defs[3]-1)//bin_y)+1]
+            ((init_curr_defs[0] - 1) // bin_x) + 1,
+            ((init_curr_defs[1] - 1) // bin_x) + 1,
+            ((init_curr_defs[2] - 1) // bin_y) + 1,
+            ((init_curr_defs[3] - 1) // bin_y) + 1,
+        ]
         # check data outside these regions by 8/bin_y pixels
-        y_buff = 20//bin_y
-        mod_defs = [curr_defs[0]-1, curr_defs[1],
-                    curr_defs[2]-1-y_buff-offset,
-                    curr_defs[3]+y_buff-offset]
-        expanded_data = flat_data[mod_defs[2]:mod_defs[3],
-                                  mod_defs[0]:mod_defs[1]]
-        #------------------
+        y_buff = 20 // bin_y
+        mod_defs = [
+            curr_defs[0] - 1,
+            curr_defs[1],
+            curr_defs[2] - 1 - y_buff - offset,
+            curr_defs[3] + y_buff - offset,
+        ]
+        expanded_data = flat_data[mod_defs[2] : mod_defs[3], mod_defs[0] : mod_defs[1]]
+        # ------------------
         # fit for best new center!
         init_yprof = numpy.sum(expanded_data, axis=1)
-        y_prof = (init_yprof - init_yprof.min())/(
-            init_yprof.max()-init_yprof.min())
+        y_prof = (init_yprof - init_yprof.min()) / (init_yprof.max() - init_yprof.min())
         # center = halfway between edges where it drops below 0.001
-        bright_inds = numpy.nonzero(y_prof>0.1)[0]
-        new_ymin = bright_inds[0]-1
-        new_ymax = bright_inds[-1]+1
-        orig_ctr = 0.5*float(len(y_prof))
-        new_ctr = 0.5*(new_ymin+new_ymax)
+        bright_inds = numpy.nonzero(y_prof > 0.1)[0]
+        new_ymin = bright_inds[0] - 1
+        new_ymax = bright_inds[-1] + 1
+        orig_ctr = 0.5 * float(len(y_prof))
+        new_ctr = 0.5 * (new_ymin + new_ymax)
         if plot:
             pylab.figure()
-            pylab.plot(y_prof, color='b')
-            pylab.axvline(orig_ctr, color='r')
-            pylab.axvline(new_ctr, color='g')
+            pylab.plot(y_prof, color="b")
+            pylab.axvline(orig_ctr, color="r")
+            pylab.axvline(new_ctr, color="g")
             pylab.show()
         # now adjust the slitlet definitions!
-        y_shift = bin_y*int(new_ctr-orig_ctr)
+        y_shift = bin_y * int(new_ctr - orig_ctr)
         if verbose:
-            print('Fitted shift of %d (unbinned) pixels for slitlet %d' % (
-                y_shift, i+1))
+            print(
+                "Fitted shift of %d (unbinned) pixels for slitlet %d" % (y_shift, i + 1)
+            )
         y_shift_vals.append(y_shift)
-        final_defs = [init_curr_defs[0],
-                      init_curr_defs[1],
-                      init_curr_defs[2]+y_shift,
-                      init_curr_defs[3]+y_shift]
-        new_slitlet_defs[str(i+1)] = final_defs
+        final_defs = [
+            init_curr_defs[0],
+            init_curr_defs[1],
+            init_curr_defs[2] + y_shift,
+            init_curr_defs[3] + y_shift,
+        ]
+        new_slitlet_defs[str(i + 1)] = final_defs
     # finally, use a single global shift if requested
     if shift_global:
         best_shift = int(numpy.mean(numpy.array(y_shift_vals)))
         if verbose:
-            print('Best global shift is %d (unbinned) pixels' % best_shift)
+            print("Best global shift is %d (unbinned) pixels" % best_shift)
         final_slitlet_defs = {}
         for i in range(25):
-            init_curr_defs = baseline_defs[str(i+1)]
-            final_defs = [init_curr_defs[0],
-                          init_curr_defs[1],
-                          init_curr_defs[2]+best_shift,
-                          init_curr_defs[3]+best_shift]
-            final_slitlet_defs[str(i+1)] = final_defs
+            init_curr_defs = baseline_defs[str(i + 1)]
+            final_defs = [
+                init_curr_defs[0],
+                init_curr_defs[1],
+                init_curr_defs[2] + best_shift,
+                init_curr_defs[3] + best_shift,
+            ]
+            final_slitlet_defs[str(i + 1)] = final_defs
     else:
         final_slitlet_defs = new_slitlet_defs
     # save it!
-    f3 = open(output_fn, 'wb')
+    f3 = open(output_fn, "wb")
     pickle.dump(final_slitlet_defs, f3)
     f3.close()
     return
 
+
 # Fred's update (sag)
-def interslice_cleanup(input_fn, output_fn,
-                       slitlet_def_file=None,
-                       bin_x=None, bin_y=None,
-                       data_hdu=0,
-                       offset = 0.4,
-                       buffer = 0,
-                       radius=10,
-                       nsig_lim=5.0,
-                       verbose=False,
-                       plot=False,
-                       savefigs=False,
-                       save_prefix='cleanup_',
-                       method='2D'):
+def interslice_cleanup(
+    input_fn,
+    output_fn,
+    slitlet_def_file=None,
+    bin_x=None,
+    bin_y=None,
+    data_hdu=0,
+    offset=0.4,
+    buffer=0,
+    radius=10,
+    nsig_lim=5.0,
+    verbose=False,
+    plot=False,
+    savefigs=False,
+    save_prefix="cleanup_",
+    method="2D",
+):
     """Uses the dark interslice regions of the detector to interpolate the
-    scattered light over the entire detector. 
-    
-    Note that setting nsig_lim to 3 (as it historically has been) can cause 
-    problems by sigma clipping the scattered light, not just cosmic rays. For 
+    scattered light over the entire detector.
+
+    Note that setting nsig_lim to 3 (as it historically has been) can cause
+    problems by sigma clipping the scattered light, not just cosmic rays. For
     a halframe detector with y binning 2, there are 1024 x 4096 pixels.
     With sigma values as follows, this is how many pixels lie above:
      - 3.0 sigma (99.73%): ~11,323 px
@@ -1384,7 +1538,7 @@ def interslice_cleanup(input_fn, output_fn,
      (This however assumes a Gaussian distribution, which isn't at all the case
      but still useful as a guide/metric.)
     """
-    #------------------------------------
+    # ------------------------------------
     # 1) Open the flat field
     f = pyfits.open(input_fn)
     header = f[data_hdu].header
@@ -1393,22 +1547,22 @@ def interslice_cleanup(input_fn, output_fn,
     # Check if half-frame
     halfframe = is_halfframe(input_fn)
     # check which channel (blue / red) it is!!
-    camera = header['CAMERA']
-    
-    #------------------------------------
+    camera = header["CAMERA"]
+
+    # ------------------------------------
     # 2) Get the slitlets boundaries
     if slitlet_def_file != None:
-        f2 = open(slitlet_def_file, 'rb')
+        f2 = open(slitlet_def_file, "rb")
         init_slitlet_defs = pickle.load(f2)
         f2.close()
-    elif camera == 'WiFeSRed':
+    elif camera == "WiFeSRed":
         init_slitlet_defs = red_slitlet_defs
     else:
         init_slitlet_defs = blue_slitlet_defs
 
     # check for binning, if no specified read from header
     try:
-        bin_temp = header['CCDSUM'].split()
+        bin_temp = header["CCDSUM"].split()
         default_bin_x = int(float(bin_temp[0]))
         default_bin_y = int(float(bin_temp[1]))
     except:
@@ -1434,174 +1588,183 @@ def interslice_cleanup(input_fn, output_fn,
 
     # NEW MJC CODE: ADD IN BUFFER
     slitlet_defs = {}
-    for i in range(1,26):
+    for i in range(1, 26):
         slit_num = str(i)
         init_slitdefs = init_slitlet_defs[slit_num]
         slitlet_defs[slit_num] = [
             init_slitdefs[0],
             init_slitdefs[1],
-            max(init_slitdefs[2]-buffer-frame_offset,1),
-            min(init_slitdefs[3]+buffer-frame_offset,4096)]
-    
-    #------------------------------------
+            max(init_slitdefs[2] - buffer - frame_offset, 1),
+            min(init_slitdefs[3] + buffer - frame_offset, 4096),
+        ]
+
+    # ------------------------------------
     # 3) Create temporary storage structure
     inter_smooth = numpy.zeros_like(data)
     fitted = numpy.zeros_like(data)
 
-    #------------------------------------
+    # ------------------------------------
     # 4) Get rid of the 'science-full region' and leave only the interslice
     # (and smooth it as well)
     for slit in slitlets_n:
         # Get the slit boundaries
-        [xmin,xmax,ymin,ymax] = slitlet_defs[str(slit)]
+        [xmin, xmax, ymin, ymax] = slitlet_defs[str(slit)]
         # Account for binning
-        xmin = numpy.round(xmin//bin_x)
-        xmax = numpy.round(xmax//bin_x)
-        ymin = numpy.round(ymin//bin_y)
-        ymax = numpy.round(ymax//bin_y)
+        xmin = numpy.round(xmin // bin_x)
+        xmax = numpy.round(xmax // bin_x)
+        ymin = numpy.round(ymin // bin_y)
+        ymax = numpy.round(ymax // bin_y)
 
         # Clear the appropriate region in temporary structure
-        inter_smooth[ymin:ymax,xmin:xmax] = numpy.nan
+        inter_smooth[ymin:ymax, xmin:xmax] = numpy.nan
         # Now, smooth the remaining interslice region
         if slit == 1:
             symin = ymax
             symax = numpy.shape(data)[0]
-        else :
+        else:
             symin = ymax
-            symax = numpy.round(slitlet_defs[str(slit-1)][2]//bin_y)
+            symax = numpy.round(slitlet_defs[str(slit - 1)][2] // bin_y)
 
         # Need to get rid of cosmic rays
         # here's a quick and dirty way of doing it ...
         # better idea anyone ?
-        tmp = numpy.zeros_like(data[symin:symax,xmin:xmax])
-        median = numpy.median(data[symin:symax,xmin:xmax])
-        std = numpy.std(data[symin:symax,xmin:xmax])        
-        tmp[data[symin:symax,xmin:xmax]< (median+nsig_lim*std)] = \
-            data[symin:symax,xmin:xmax][data[symin:symax,xmin:xmax]< 
-                                        (median+nsig_lim*std)]
+        tmp = numpy.zeros_like(data[symin:symax, xmin:xmax])
+        median = numpy.median(data[symin:symax, xmin:xmax])
+        std = numpy.std(data[symin:symax, xmin:xmax])
+        tmp[data[symin:symax, xmin:xmax] < (median + nsig_lim * std)] = data[
+            symin:symax, xmin:xmax
+        ][data[symin:symax, xmin:xmax] < (median + nsig_lim * std)]
 
-        if method=='2D':
-            inter_smooth[symin:symax,xmin:xmax] = \
-                ndimage.gaussian_filter(tmp,
-                                        sigma=[radius,radius])
-        elif method=='1D':
-            inter_smooth[symin:symax,xmin:xmax] += numpy.median(tmp)
+        if method == "2D":
+            inter_smooth[symin:symax, xmin:xmax] = ndimage.gaussian_filter(
+                tmp, sigma=[radius, radius]
+            )
+        elif method == "1D":
+            inter_smooth[symin:symax, xmin:xmax] += numpy.median(tmp)
         # And don't forget the extra slice
-        if slit == 25 :
-            symin=1
-            symax=ymin
-            if method=='2D':
-                inter_smooth[symin:symax,xmin:xmax] = \
-                    ndimage.gaussian_filter(data[symin:symax,xmin:xmax],
-                                            sigma=[radius,radius])
-            elif method=='1D':
-                inter_smooth[symin:symax,xmin:xmax] += numpy.median(tmp)
+        if slit == 25:
+            symin = 1
+            symax = ymin
+            if method == "2D":
+                inter_smooth[symin:symax, xmin:xmax] = ndimage.gaussian_filter(
+                    data[symin:symax, xmin:xmax], sigma=[radius, radius]
+                )
+            elif method == "1D":
+                inter_smooth[symin:symax, xmin:xmax] += numpy.median(tmp)
 
-    #------------------------------------
+    # ------------------------------------
     # 5) Great, now we can interpolate this and reconstruct the contamination
     # Do each slitlet individually to avoid overloading the memory
     # Sampling
     dx = 10
     dy = 3
     for slit in slitlets_n:
-        [xmin,xmax,y2,y3] = slitlet_defs[str(slit)]
+        [xmin, xmax, y2, y3] = slitlet_defs[str(slit)]
         # Account for binning
-        xmin = numpy.round(xmin//bin_x)
-        xmax = numpy.round(xmax//bin_x)
-        y2 = numpy.round(y2//bin_y)
-        y3 = numpy.round(y3//bin_y)
+        xmin = numpy.round(xmin // bin_x)
+        xmax = numpy.round(xmax // bin_x)
+        y2 = numpy.round(y2 // bin_y)
+        y3 = numpy.round(y3 // bin_y)
 
         if slit == 1:
             y4 = numpy.shape(data)[0]
-            y1 = numpy.round(slitlet_defs['2'][3]//bin_y)
+            y1 = numpy.round(slitlet_defs["2"][3] // bin_y)
         elif slit == 25:
-            y4 = numpy.round(slitlet_defs['24'][2]//bin_y)
+            y4 = numpy.round(slitlet_defs["24"][2] // bin_y)
             y1 = 1
         # Special case we have to extrapolate for the half slitlet rather than
         # interpolate as there is not dark interslit region on the other side.
         elif slit == 13 and halfframe:
-            y4 = numpy.round(slitlet_defs[str(slit-1)][2]//bin_y)
-            y1 = y2 
+            y4 = numpy.round(slitlet_defs[str(slit - 1)][2] // bin_y)
+            y1 = y2
         else:
-            y4 = numpy.round(slitlet_defs[str(slit-1)][2]//bin_y)
-            y1 = numpy.round(slitlet_defs[str(slit+1)][3]//bin_y)   
+            y4 = numpy.round(slitlet_defs[str(slit - 1)][2] // bin_y)
+            y1 = numpy.round(slitlet_defs[str(slit + 1)][3] // bin_y)
 
         # Select a subsample of point to do the integration
-        x = numpy.arange(xmin+3,xmax-3,dx)
+        x = numpy.arange(xmin + 3, xmax - 3, dx)
 
         if slit == 13 and halfframe:
-            y = numpy.arange(y3+1,y4-1,dy)
+            y = numpy.arange(y3 + 1, y4 - 1, dy)
         else:
-            y = numpy.append(numpy.arange(y1+1,y2-1,dy),
-                            numpy.arange(y3+1,y4-1,dy))
-        grid = numpy.zeros((len(y),len(x)))
+            y = numpy.append(
+                numpy.arange(y1 + 1, y2 - 1, dy), numpy.arange(y3 + 1, y4 - 1, dy)
+            )
+        grid = numpy.zeros((len(y), len(x)))
 
         for i in range(len(x)):
             for j in range(len(y)):
-                grid[j,i] = inter_smooth[y[j],x[i]]
+                grid[j, i] = inter_smooth[y[j], x[i]]
 
-        #------------------------------------
+        # ------------------------------------
         # 6) Actually perform the interpolation
 
         # Note : because of the large gap to fill, kx and ky have little effect
         # reconstruct missing slice
-        xall = numpy.arange(xmin,xmax,1)
-        yall = numpy.arange(y1,y4,1)
+        xall = numpy.arange(xmin, xmax, 1)
+        yall = numpy.arange(y1, y4, 1)
 
         if slit == 13 and halfframe:
-            func = interp.interp2d(y, x, grid.T, bounds_error=False,
-                                   fill_value=None)
-            fitted[y1:y4,xmin:xmax] = func(yall,xall).T
+            func = interp.interp2d(y, x, grid.T, bounds_error=False, fill_value=None)
+            fitted[y1:y4, xmin:xmax] = func(yall, xall).T
 
         else:
-            func = interp.RectBivariateSpline(y,x,grid, kx=1,ky=1)
-            fitted[y1:y4,xmin:xmax] = func(yall,xall)
-            
-    #------------------------------------
+            func = interp.RectBivariateSpline(y, x, grid, kx=1, ky=1)
+            fitted[y1:y4, xmin:xmax] = func(yall, xall)
+
+    # ------------------------------------
     # 7) All done ! Let's save it all ...
     f = pyfits.open(input_fn)
     f[0].data = fitted
-    f.writeto(input_fn[:-5]+'_corr.fits',overwrite=True) # Save the corretion image separately just in case
-    f[0].data = data - fitted + offset*numpy.mean(fitted)
-    f[0].header.set('PYWIFES', __version__, 'PyWiFeS version')
-    f.writeto(output_fn,overwrite=True)
+    f.writeto(
+        input_fn[:-5] + "_corr.fits", overwrite=True
+    )  # Save the corretion image separately just in case
+    f[0].data = data - fitted + offset * numpy.mean(fitted)
+    f[0].header.set("PYWIFES", __version__, "PyWiFeS version")
+    f.writeto(output_fn, overwrite=True)
     f.close()
-    if verbose:    
-        print(' Additive offset:',offset*numpy.mean(fitted))
+    if verbose:
+        print(" Additive offset:", offset * numpy.mean(fitted))
     # 8) Plot anything ?
     if plot or savefigs:
         myvmax = numpy.max(fitted)
-        #------------------
+        # ------------------
         fig = pylab.figure()
-        pylab.imshow(data, vmin=0,vmax=myvmax,cmap='nipy_spectral', origin='lower')
-        pylab.title('Pre-corrected '+input_fn.split('/')[-1])
+        pylab.imshow(data, vmin=0, vmax=myvmax, cmap="nipy_spectral", origin="lower")
+        pylab.title("Pre-corrected " + input_fn.split("/")[-1])
         if savefigs:
-            save_fn = save_prefix+'flat_orig_data.png'
+            save_fn = save_prefix + "flat_orig_data.png"
             pylab.savefig(save_fn)
-        #------------------
+        # ------------------
         pylab.figure()
-        pylab.imshow(fitted,vmin=0,vmax=myvmax,cmap='nipy_spectral', origin='lower')
-        pylab.title('Fitted contamination for '+input_fn.split('/')[-1])
+        pylab.imshow(fitted, vmin=0, vmax=myvmax, cmap="nipy_spectral", origin="lower")
+        pylab.title("Fitted contamination for " + input_fn.split("/")[-1])
         if savefigs:
-            save_fn = save_prefix+'flat_glow_data.png'
+            save_fn = save_prefix + "flat_glow_data.png"
             pylab.savefig(save_fn)
-        #------------------            
+        # ------------------
         pylab.figure()
-        pylab.imshow(data-fitted+offset*numpy.mean(fitted),vmin=0,
-                     vmax=myvmax,cmap='nipy_spectral', origin='lower')
-        pylab.title('Corrected '+output_fn.split('/')[-1])
+        pylab.imshow(
+            data - fitted + offset * numpy.mean(fitted),
+            vmin=0,
+            vmax=myvmax,
+            cmap="nipy_spectral",
+            origin="lower",
+        )
+        pylab.title("Corrected " + output_fn.split("/")[-1])
         if savefigs:
-            save_fn = save_prefix+'flat_sub_data.png'
+            save_fn = save_prefix + "flat_sub_data.png"
             pylab.savefig(save_fn)
         if plot:
             pylab.show()
     return
 
-def wifes_slitlet_mef(inimg, outimg, data_hdu=0,
-                      bin_x=None, bin_y=None,
-                      slitlet_def_file=None):
+
+def wifes_slitlet_mef(
+    inimg, outimg, data_hdu=0, bin_x=None, bin_y=None, slitlet_def_file=None
+):
     f = pyfits.open(inimg)
-    #outfits = pyfits.HDUList([f[0]])
+    # outfits = pyfits.HDUList([f[0]])
     outfits = pyfits.HDUList([pyfits.PrimaryHDU(header=f[0].header)])
     old_hdr = f[data_hdu].header
     full_data = f[data_hdu].data
@@ -1609,24 +1772,24 @@ def wifes_slitlet_mef(inimg, outimg, data_hdu=0,
     # check if halfframe
     halfframe = is_halfframe(inimg)
     # check which channel (blue / red) it is!!
-    camera = old_hdr['CAMERA']
-    rdnoise = old_hdr['RDNOISE']
+    camera = old_hdr["CAMERA"]
+    rdnoise = old_hdr["RDNOISE"]
     # get slitlet definitions!
     # new ones if defined, otherwise use baseline values!
     if slitlet_def_file != None:
-        f2 = open(slitlet_def_file, 'rb')
+        f2 = open(slitlet_def_file, "rb")
         try:
-            slitlet_defs = pickle.load(f2, fix_imports=True, encoding='latin')
+            slitlet_defs = pickle.load(f2, fix_imports=True, encoding="latin")
         except:
-            slitlet_defs = pickle.load(f2) # for python 2.7
+            slitlet_defs = pickle.load(f2)  # for python 2.7
         f2.close()
-    elif camera == 'WiFeSRed':
+    elif camera == "WiFeSRed":
         slitlet_defs = red_slitlet_defs
     else:
         slitlet_defs = blue_slitlet_defs
     # check for binning, if no specified read from header
     try:
-        bin_temp = old_hdr['CCDSUM'].split()
+        bin_temp = old_hdr["CCDSUM"].split()
         default_bin_x = int(float(bin_temp[0]))
         default_bin_y = int(float(bin_temp[1]))
     except:
@@ -1636,183 +1799,211 @@ def wifes_slitlet_mef(inimg, outimg, data_hdu=0,
         bin_x = default_bin_x
     if bin_y == None:
         bin_y = default_bin_y
-    #---------------------------
+    # ---------------------------
     # ** NEW VERSION 0.5.8 - CREATE DQ IMAGE **
     dq_img = numpy.zeros(numpy.shape(full_data))
     # flag bad pixels on new detectors
     epoch = determine_detector_epoch(inimg)
     if int(float(epoch[1])) > 3:
-        if camera == 'WiFeSRed':
+        if camera == "WiFeSRed":
             if halfframe:
-                y_bad_min = (3242-2048)//bin_y-1
-                y_bad_max = 2048//bin_y
+                y_bad_min = (3242 - 2048) // bin_y - 1
+                y_bad_max = 2048 // bin_y
             else:
-                y_bad_min = 3282//bin_y-1
-                y_bad_max = 4096//bin_y
-            x_bad_1 = 774//bin_x-1
-            x_bad_2 = 775//bin_x-1
-            dq_img[y_bad_min:y_bad_max,x_bad_1] = 1
-            dq_img[y_bad_min:y_bad_max,x_bad_2] = 1
+                y_bad_min = 3282 // bin_y - 1
+                y_bad_max = 4096 // bin_y
+            x_bad_1 = 774 // bin_x - 1
+            x_bad_2 = 775 // bin_x - 1
+            dq_img[y_bad_min:y_bad_max, x_bad_1] = 1
+            dq_img[y_bad_min:y_bad_max, x_bad_2] = 1
         else:
-            x_bad = 1529//bin_x-1
+            x_bad = 1529 // bin_x - 1
             if halfframe:
                 y_bad_min = 0
-                y_bad_max = 2048//bin_y
+                y_bad_max = 2048 // bin_y
             else:
-                y_bad_min = 752//bin_y-1
-                y_bad_max = 4096//bin_y
-            dq_img[y_bad_min:y_bad_max,x_bad] = 1
-    #---------------------------
+                y_bad_min = 752 // bin_y - 1
+                y_bad_max = 4096 // bin_y
+            dq_img[y_bad_min:y_bad_max, x_bad] = 1
+    # ---------------------------
     # for each slitlet, save it to a single header extension
     if halfframe:
         nslits = 12
-        #offset = 4096//bin_y
-        old_ymin = int(float(
-            old_hdr['DETSEC'].split(',')[1].split(':')[0]))-1
-        offset = old_ymin//bin_y
+        # offset = 4096//bin_y
+        old_ymin = int(float(old_hdr["DETSEC"].split(",")[1].split(":")[0])) - 1
+        offset = old_ymin // bin_y
     else:
         nslits = 25
         offset = 0
     for i in range(25):
-        init_curr_defs = slitlet_defs[str(i+1)]
+        init_curr_defs = slitlet_defs[str(i + 1)]
         # convert to binned values
         curr_defs = [
-            ((init_curr_defs[0]-1)//bin_x)+1,
-            ((init_curr_defs[1]-1)//bin_x)+1,
-            ((init_curr_defs[2]-1)//bin_y)+1,
-            ((init_curr_defs[3]-1)//bin_y)+1]
+            ((init_curr_defs[0] - 1) // bin_x) + 1,
+            ((init_curr_defs[1] - 1) // bin_x) + 1,
+            ((init_curr_defs[2] - 1) // bin_y) + 1,
+            ((init_curr_defs[3] - 1) // bin_y) + 1,
+        ]
         # horrible kluge to make sure everything has the same dimensions!
-        if (curr_defs[1]-curr_defs[0]+1) != (4096//bin_x):
+        if (curr_defs[1] - curr_defs[0] + 1) != (4096 // bin_x):
             curr_defs[1] -= 1
-        if (curr_defs[3]-curr_defs[2]+1) != (86//bin_y):
+        if (curr_defs[3] - curr_defs[2] + 1) != (86 // bin_y):
             curr_defs[3] -= 1
         # get the data
-        dim_str = '[%d:%d,%d:%d]' % (
-            curr_defs[0], curr_defs[1],
-            curr_defs[2], curr_defs[3])
-        mod_defs = [curr_defs[0]-1, curr_defs[1],
-                    curr_defs[2]-1-offset, curr_defs[3]-offset]
-        #print curr_defs, (curr_defs[3]-curr_defs[2]), init_curr_defs, (
+        dim_str = "[%d:%d,%d:%d]" % (
+            curr_defs[0],
+            curr_defs[1],
+            curr_defs[2],
+            curr_defs[3],
+        )
+        mod_defs = [
+            curr_defs[0] - 1,
+            curr_defs[1],
+            curr_defs[2] - 1 - offset,
+            curr_defs[3] - offset,
+        ]
+        # print curr_defs, (curr_defs[3]-curr_defs[2]), init_curr_defs, (
         #    init_curr_defs[3]-init_curr_defs[2])
-        if halfframe and ((i+1) > nslits):
-            new_data = numpy.zeros([86//bin_y, 4096//bin_x], dtype='d')
+        if halfframe and ((i + 1) > nslits):
+            new_data = numpy.zeros([86 // bin_y, 4096 // bin_x], dtype="d")
         else:
-            new_data = full_data[mod_defs[2]:mod_defs[3],
-                                 mod_defs[0]:mod_defs[1]]
+            new_data = full_data[mod_defs[2] : mod_defs[3], mod_defs[0] : mod_defs[1]]
         # create fits hdu
-        hdu_name = 'SCI%d' % (i+1)
+        hdu_name = "SCI%d" % (i + 1)
         new_hdu = pyfits.ImageHDU(new_data, old_hdr, name=hdu_name)
-        new_hdu.header.set('DETSEC',  dim_str)
-        new_hdu.header.set('DATASEC', dim_str)
-        new_hdu.header.set('TRIMSEC', dim_str)
+        new_hdu.header.set("DETSEC", dim_str)
+        new_hdu.header.set("DATASEC", dim_str)
+        new_hdu.header.set("TRIMSEC", dim_str)
         outfits.append(new_hdu)
         gc.collect()
-    #print squirrel
+    # print squirrel
     # VARIANCE EXTENSIONS
     for i in range(25):
-        init_curr_defs = slitlet_defs[str(i+1)]
+        init_curr_defs = slitlet_defs[str(i + 1)]
         # convert to binned values
         curr_defs = [
-            ((init_curr_defs[0]-1)//bin_x)+1,
-            ((init_curr_defs[1]-1)//bin_x)+1,
-            ((init_curr_defs[2]-1)//bin_y)+1,
-            ((init_curr_defs[3]-1)//bin_y)+1]
+            ((init_curr_defs[0] - 1) // bin_x) + 1,
+            ((init_curr_defs[1] - 1) // bin_x) + 1,
+            ((init_curr_defs[2] - 1) // bin_y) + 1,
+            ((init_curr_defs[3] - 1) // bin_y) + 1,
+        ]
         # horrible kluge to make sure everything has the same dimensions!
-        if (curr_defs[1]-curr_defs[0]+1) != (4096//bin_x):
+        if (curr_defs[1] - curr_defs[0] + 1) != (4096 // bin_x):
             curr_defs[1] -= 1
-        if (curr_defs[3]-curr_defs[2]+1) != (86//bin_y):
+        if (curr_defs[3] - curr_defs[2] + 1) != (86 // bin_y):
             curr_defs[3] -= 1
-        #print curr_defs
-        #print squirrel
+        # print curr_defs
+        # print squirrel
         # get the data
-        dim_str = '[%d:%d,%d:%d]' % (
-            curr_defs[0], curr_defs[1],
-            curr_defs[2], curr_defs[3])
-        mod_defs = [curr_defs[0]-1, curr_defs[1],
-                    curr_defs[2]-1-offset, curr_defs[3]-offset]
-        if halfframe and ((i+1) > nslits):
-            new_data = numpy.zeros([86//bin_y, 4096//bin_x], dtype='d')
+        dim_str = "[%d:%d,%d:%d]" % (
+            curr_defs[0],
+            curr_defs[1],
+            curr_defs[2],
+            curr_defs[3],
+        )
+        mod_defs = [
+            curr_defs[0] - 1,
+            curr_defs[1],
+            curr_defs[2] - 1 - offset,
+            curr_defs[3] - offset,
+        ]
+        if halfframe and ((i + 1) > nslits):
+            new_data = numpy.zeros([86 // bin_y, 4096 // bin_x], dtype="d")
         else:
-            new_data = full_data[mod_defs[2]:mod_defs[3],
-                                 mod_defs[0]:mod_defs[1]]
-        var_data = new_data+rdnoise**2
+            new_data = full_data[mod_defs[2] : mod_defs[3], mod_defs[0] : mod_defs[1]]
+        var_data = new_data + rdnoise**2
         # create fits hdu
-        hdu_name = 'VAR%d' % (i+1)
+        hdu_name = "VAR%d" % (i + 1)
         new_hdu = pyfits.ImageHDU(var_data, old_hdr, name=hdu_name)
-        new_hdu.header.set('DETSEC',  dim_str)
-        new_hdu.header.set('DATASEC', dim_str)
-        new_hdu.header.set('TRIMSEC', dim_str)
+        new_hdu.header.set("DETSEC", dim_str)
+        new_hdu.header.set("DATASEC", dim_str)
+        new_hdu.header.set("TRIMSEC", dim_str)
         outfits.append(new_hdu)
         gc.collect()
     # DATA QUALITY EXTENSIONS
     for i in range(25):
-        init_curr_defs = slitlet_defs[str(i+1)]
+        init_curr_defs = slitlet_defs[str(i + 1)]
         # convert to binned values
         curr_defs = [
-            ((init_curr_defs[0]-1)//bin_x)+1,
-            ((init_curr_defs[1]-1)//bin_x)+1,
-            ((init_curr_defs[2]-1)//bin_y)+1,
-            ((init_curr_defs[3]-1)//bin_y)+1]
+            ((init_curr_defs[0] - 1) // bin_x) + 1,
+            ((init_curr_defs[1] - 1) // bin_x) + 1,
+            ((init_curr_defs[2] - 1) // bin_y) + 1,
+            ((init_curr_defs[3] - 1) // bin_y) + 1,
+        ]
         # horrible kluge to make sure everything has the same dimensions!
-        if (curr_defs[1]-curr_defs[0]+1) != (4096//bin_x):
+        if (curr_defs[1] - curr_defs[0] + 1) != (4096 // bin_x):
             curr_defs[1] -= 1
-        if (curr_defs[3]-curr_defs[2]+1) != (86//bin_y):
+        if (curr_defs[3] - curr_defs[2] + 1) != (86 // bin_y):
             curr_defs[3] -= 1
         # get the data
-        dim_str = '[%d:%d,%d:%d]' % (
-            curr_defs[0], curr_defs[1],
-            curr_defs[2], curr_defs[3])
-        mod_defs = [curr_defs[0]-1, curr_defs[1],
-                    curr_defs[2]-1-offset, curr_defs[3]-offset]
-        ny = curr_defs[3]-curr_defs[2]+1
-        nx = curr_defs[1]-curr_defs[0]+1
-        if halfframe and ((i+1) > nslits):
-            dq_data = numpy.ones([ny,nx])
+        dim_str = "[%d:%d,%d:%d]" % (
+            curr_defs[0],
+            curr_defs[1],
+            curr_defs[2],
+            curr_defs[3],
+        )
+        mod_defs = [
+            curr_defs[0] - 1,
+            curr_defs[1],
+            curr_defs[2] - 1 - offset,
+            curr_defs[3] - offset,
+        ]
+        ny = curr_defs[3] - curr_defs[2] + 1
+        nx = curr_defs[1] - curr_defs[0] + 1
+        if halfframe and ((i + 1) > nslits):
+            dq_data = numpy.ones([ny, nx])
         else:
-            dq_data = dq_img[mod_defs[2]:mod_defs[3],
-                             mod_defs[0]:mod_defs[1]]
+            dq_data = dq_img[mod_defs[2] : mod_defs[3], mod_defs[0] : mod_defs[1]]
         # OLD METHOD
-        #if halfframe and ((i+1) > nslits):
+        # if halfframe and ((i+1) > nslits):
         #    dq_data = numpy.ones([ny,nx])
-        #else:
+        # else:
         #    dq_data = numpy.zeros([ny,nx])
         # create fits hdu
-        hdu_name = 'DQ%d' % (i+1)
+        hdu_name = "DQ%d" % (i + 1)
         new_hdu = pyfits.ImageHDU(dq_data, old_hdr, name=hdu_name)
-        new_hdu.header.set('DETSEC',  dim_str)
-        new_hdu.header.set('DATASEC', dim_str)
-        new_hdu.header.set('TRIMSEC', dim_str)
+        new_hdu.header.set("DETSEC", dim_str)
+        new_hdu.header.set("DATASEC", dim_str)
+        new_hdu.header.set("TRIMSEC", dim_str)
         outfits.append(new_hdu)
         gc.collect()
-    outfits[0].header.set('PYWIFES', __version__, 'PyWiFeS version')
+    outfits[0].header.set("PYWIFES", __version__, "PyWiFeS version")
     outfits.writeto(outimg, overwrite=True)
     return
 
-def wifes_slitlet_mef_ns(inimg, outimg_obj, outimg_sky,
-                         data_hdu=0, bin_x=None, bin_y=None, nod_dy=80,
-                         slitlet_def_file=None):
+
+def wifes_slitlet_mef_ns(
+    inimg,
+    outimg_obj,
+    outimg_sky,
+    data_hdu=0,
+    bin_x=None,
+    bin_y=None,
+    nod_dy=80,
+    slitlet_def_file=None,
+):
     f = pyfits.open(inimg)
     outfits_obj = pyfits.HDUList([pyfits.PrimaryHDU(header=f[0].header)])
     outfits_sky = pyfits.HDUList([pyfits.PrimaryHDU(header=f[0].header)])
     old_hdr = f[data_hdu].header
     full_data = f[data_hdu].data
     f.close()
-    rdnoise = old_hdr['RDNOISE']
+    rdnoise = old_hdr["RDNOISE"]
     # check which channel (blue / red) it is!!
-    camera = old_hdr['CAMERA']
+    camera = old_hdr["CAMERA"]
     # get slitlet definitions!
     # new ones if defined, otherwise use baseline values!
     if slitlet_def_file != None:
-        f2 = open(slitlet_def_file, 'rb')
-        slitlet_defs = pickle.load(f2, fix_imports=True, encoding='latin')
+        f2 = open(slitlet_def_file, "rb")
+        slitlet_defs = pickle.load(f2, fix_imports=True, encoding="latin")
         f2.close()
-    elif camera == 'WiFeSRed':
+    elif camera == "WiFeSRed":
         slitlet_defs = red_slitlet_defs
     else:
         slitlet_defs = blue_slitlet_defs
     # check for binning, if no specified read from header
     try:
-        bin_temp = old_hdr['CCDSUM'].split()
+        bin_temp = old_hdr["CCDSUM"].split()
         default_bin_x = int(float(bin_temp[0]))
         default_bin_y = int(float(bin_temp[1]))
     except:
@@ -1822,248 +2013,267 @@ def wifes_slitlet_mef_ns(inimg, outimg_obj, outimg_sky,
         bin_x = default_bin_x
     if bin_y == None:
         bin_y = default_bin_y
-    #------------------------------------
+    # ------------------------------------
     # for each slitlet, save it to a single header extension
     for i in range(nslits):
-        init_curr_defs = slitlet_defs[str(i+1)]
-        #------------------
+        init_curr_defs = slitlet_defs[str(i + 1)]
+        # ------------------
         # convert to binned values
         obj_defs = [
-            ((init_curr_defs[0]-1)//bin_x)+1,
-            ((init_curr_defs[1]-1)//bin_x)+1,
-            ((init_curr_defs[2]-1)//bin_y)+1,
-            ((init_curr_defs[3]-1)//bin_y)+1]
+            ((init_curr_defs[0] - 1) // bin_x) + 1,
+            ((init_curr_defs[1] - 1) // bin_x) + 1,
+            ((init_curr_defs[2] - 1) // bin_y) + 1,
+            ((init_curr_defs[3] - 1) // bin_y) + 1,
+        ]
         sky_defs = [
-            ((init_curr_defs[0]-1)//bin_x)+1,
-            ((init_curr_defs[1]-1)//bin_x)+1,
-            ((init_curr_defs[2]-1+nod_dy)//bin_y)+1,
-            ((init_curr_defs[3]-1+nod_dy)//bin_y)+1]
-        #------------------
+            ((init_curr_defs[0] - 1) // bin_x) + 1,
+            ((init_curr_defs[1] - 1) // bin_x) + 1,
+            ((init_curr_defs[2] - 1 + nod_dy) // bin_y) + 1,
+            ((init_curr_defs[3] - 1 + nod_dy) // bin_y) + 1,
+        ]
+        # ------------------
         # horrible kluge to make sure everything has the same dimensions!
-        if (obj_defs[1]-obj_defs[0]+1) != (4096//bin_x):
+        if (obj_defs[1] - obj_defs[0] + 1) != (4096 // bin_x):
             obj_defs[1] -= 1
-        if (obj_defs[3]-obj_defs[2]+1) != (86//bin_y):
+        if (obj_defs[3] - obj_defs[2] + 1) != (86 // bin_y):
             obj_defs[3] -= 1
-        if (sky_defs[1]-sky_defs[0]+1) != (4096//bin_x):
+        if (sky_defs[1] - sky_defs[0] + 1) != (4096 // bin_x):
             sky_defs[1] -= 1
-        if (sky_defs[3]-sky_defs[2]+1) != (86//bin_y):
-            sky_defs[3] -= (sky_defs[3]-sky_defs[2]+1) - (86//bin_y)
-            #sky_defs[3] -= 1
-        #------------------
+        if (sky_defs[3] - sky_defs[2] + 1) != (86 // bin_y):
+            sky_defs[3] -= (sky_defs[3] - sky_defs[2] + 1) - (86 // bin_y)
+            # sky_defs[3] -= 1
+        # ------------------
         # get the object data
-        obj_dim_str = '[%d:%d,%d:%d]' % (
-            obj_defs[0], obj_defs[1],
-            obj_defs[2], obj_defs[3])
-        obj_mod_defs = [obj_defs[0]-1, obj_defs[1],
-                        obj_defs[2]-1, obj_defs[3]]
-        obj_data = full_data[obj_mod_defs[2]:obj_mod_defs[3],
-                             obj_mod_defs[0]:obj_mod_defs[1]]
+        obj_dim_str = "[%d:%d,%d:%d]" % (
+            obj_defs[0],
+            obj_defs[1],
+            obj_defs[2],
+            obj_defs[3],
+        )
+        obj_mod_defs = [obj_defs[0] - 1, obj_defs[1], obj_defs[2] - 1, obj_defs[3]]
+        obj_data = full_data[
+            obj_mod_defs[2] : obj_mod_defs[3], obj_mod_defs[0] : obj_mod_defs[1]
+        ]
         # kill outer 3//bin_y pixels!!
-        ykill = 4//bin_y
-        obj_data[:ykill,:]  *= 0.0
-        obj_data[-ykill:,:] *= 0.0
+        ykill = 4 // bin_y
+        obj_data[:ykill, :] *= 0.0
+        obj_data[-ykill:, :] *= 0.0
         # create fits hdu for object
-        hdu_name = 'SCI%d' % (i+1)
+        hdu_name = "SCI%d" % (i + 1)
         obj_hdu = pyfits.ImageHDU(obj_data, old_hdr, name=hdu_name)
-        obj_hdu.header.set('DETSEC',  obj_dim_str)
-        obj_hdu.header.set('DATASEC', obj_dim_str)
-        obj_hdu.header.set('TRIMSEC', obj_dim_str)
+        obj_hdu.header.set("DETSEC", obj_dim_str)
+        obj_hdu.header.set("DATASEC", obj_dim_str)
+        obj_hdu.header.set("TRIMSEC", obj_dim_str)
         # fix the exposure time!!
-        exptime_true = float(old_hdr['EXPTIME'])
-        obj_hdu.header.set('EXPTIME', exptime_true,
-                              comment='Total NS exposure time')
+        exptime_true = float(old_hdr["EXPTIME"])
+        obj_hdu.header.set("EXPTIME", exptime_true, comment="Total NS exposure time")
         outfits_obj.append(obj_hdu)
-        #------------------
+        # ------------------
         # and the sky data
-        sky_dim_str = '[%d:%d,%d:%d]' % (
-            sky_defs[0], sky_defs[1],
-            sky_defs[2], sky_defs[3])
-        sky_mod_defs = [sky_defs[0]-1, sky_defs[1],
-                        sky_defs[2]-1, sky_defs[3]]
-        nsx = sky_mod_defs[1]-sky_mod_defs[0]
-        nsy = sky_mod_defs[3]-sky_mod_defs[2]
+        sky_dim_str = "[%d:%d,%d:%d]" % (
+            sky_defs[0],
+            sky_defs[1],
+            sky_defs[2],
+            sky_defs[3],
+        )
+        sky_mod_defs = [sky_defs[0] - 1, sky_defs[1], sky_defs[2] - 1, sky_defs[3]]
+        nsx = sky_mod_defs[1] - sky_mod_defs[0]
+        nsy = sky_mod_defs[3] - sky_mod_defs[2]
         # horrible fix to include bad NS regions definition for slitlet 1
         sky_data = numpy.zeros([nsy, nsx])
-        true_sky_data = full_data[sky_mod_defs[2]:sky_mod_defs[3],
-                                  sky_mod_defs[0]:sky_mod_defs[1]]
+        true_sky_data = full_data[
+            sky_mod_defs[2] : sky_mod_defs[3], sky_mod_defs[0] : sky_mod_defs[1]
+        ]
         tsy, tsx = numpy.shape(true_sky_data)
-        sky_data[:tsy,:tsx] = true_sky_data
+        sky_data[:tsy, :tsx] = true_sky_data
         # kill outer 3//bin_y pixels!!
-        ykill = 4//bin_y
-        sky_data[:ykill,:]  *= 0.0
-        sky_data[-ykill:,:] *= 0.0
+        ykill = 4 // bin_y
+        sky_data[:ykill, :] *= 0.0
+        sky_data[-ykill:, :] *= 0.0
         # create fits hdu for sky
-        hdu_name = 'SCI%d' % (i+1)
+        hdu_name = "SCI%d" % (i + 1)
         sky_hdu = pyfits.ImageHDU(sky_data, old_hdr, name=hdu_name)
-        sky_hdu.header.set('DETSEC',  sky_dim_str)
-        sky_hdu.header.set('DATASEC', sky_dim_str)
-        sky_hdu.header.set('TRIMSEC', sky_dim_str)
+        sky_hdu.header.set("DETSEC", sky_dim_str)
+        sky_hdu.header.set("DATASEC", sky_dim_str)
+        sky_hdu.header.set("TRIMSEC", sky_dim_str)
         # fix the exposure time!!
-        exptime_true = float(old_hdr['EXPTIME'])
-        sky_hdu.header.set('EXPTIME', exptime_true,
-                              comment='Total NS exposure time')
+        exptime_true = float(old_hdr["EXPTIME"])
+        sky_hdu.header.set("EXPTIME", exptime_true, comment="Total NS exposure time")
         outfits_sky.append(sky_hdu)
         gc.collect()
-    #------------------------------------
-    #print squirrel
+    # ------------------------------------
+    # print squirrel
     # VARIANCE EXTENSIONS
     for i in range(nslits):
-        init_curr_defs = slitlet_defs[str(i+1)]
-        #------------------
+        init_curr_defs = slitlet_defs[str(i + 1)]
+        # ------------------
         # convert to binned values
         obj_defs = [
-            ((init_curr_defs[0]-1)//bin_x)+1,
-            ((init_curr_defs[1]-1)//bin_x)+1,
-            ((init_curr_defs[2]-1)//bin_y)+1,
-            ((init_curr_defs[3]-1)//bin_y)+1]
+            ((init_curr_defs[0] - 1) // bin_x) + 1,
+            ((init_curr_defs[1] - 1) // bin_x) + 1,
+            ((init_curr_defs[2] - 1) // bin_y) + 1,
+            ((init_curr_defs[3] - 1) // bin_y) + 1,
+        ]
         sky_defs = [
-            ((init_curr_defs[0]-1)//bin_x)+1,
-            ((init_curr_defs[1]-1)//bin_x)+1,
-            ((init_curr_defs[2]-1+nod_dy)//bin_y)+1,
-            ((init_curr_defs[3]-1+nod_dy)//bin_y)+1]
-        #------------------
+            ((init_curr_defs[0] - 1) // bin_x) + 1,
+            ((init_curr_defs[1] - 1) // bin_x) + 1,
+            ((init_curr_defs[2] - 1 + nod_dy) // bin_y) + 1,
+            ((init_curr_defs[3] - 1 + nod_dy) // bin_y) + 1,
+        ]
+        # ------------------
         # horrible kluge to make sure everything has the same dimensions!
-        if (obj_defs[1]-obj_defs[0]+1) != (4096//bin_x):
+        if (obj_defs[1] - obj_defs[0] + 1) != (4096 // bin_x):
             obj_defs[1] -= 1
-        if (obj_defs[3]-obj_defs[2]+1) != (86//bin_y):
+        if (obj_defs[3] - obj_defs[2] + 1) != (86 // bin_y):
             obj_defs[3] -= 1
-        if (sky_defs[1]-sky_defs[0]+1) != (4096//bin_x):
+        if (sky_defs[1] - sky_defs[0] + 1) != (4096 // bin_x):
             sky_defs[1] -= 1
-        if (sky_defs[3]-sky_defs[2]+1) != (86//bin_y):
-            sky_defs[3] -= (sky_defs[3]-sky_defs[2]+1) - (86//bin_y)
-            #sky_defs[3] -= 1
-        #------------------
+        if (sky_defs[3] - sky_defs[2] + 1) != (86 // bin_y):
+            sky_defs[3] -= (sky_defs[3] - sky_defs[2] + 1) - (86 // bin_y)
+            # sky_defs[3] -= 1
+        # ------------------
         # get the object data
-        obj_dim_str = '[%d:%d,%d:%d]' % (
-            obj_defs[0], obj_defs[1],
-            obj_defs[2], obj_defs[3])
-        obj_mod_defs = [obj_defs[0]-1, obj_defs[1],
-                        obj_defs[2]-1, obj_defs[3]]
-        obj_data = full_data[obj_mod_defs[2]:obj_mod_defs[3],
-                             obj_mod_defs[0]:obj_mod_defs[1]]
+        obj_dim_str = "[%d:%d,%d:%d]" % (
+            obj_defs[0],
+            obj_defs[1],
+            obj_defs[2],
+            obj_defs[3],
+        )
+        obj_mod_defs = [obj_defs[0] - 1, obj_defs[1], obj_defs[2] - 1, obj_defs[3]]
+        obj_data = full_data[
+            obj_mod_defs[2] : obj_mod_defs[3], obj_mod_defs[0] : obj_mod_defs[1]
+        ]
         # kill outer 3//bin_y pixels!!
-        ykill = 4//bin_y
-        obj_data[:ykill,:]  *= 0.0
-        obj_data[-ykill:,:] *= 0.0
-        obj_var = obj_data+rdnoise**2
+        ykill = 4 // bin_y
+        obj_data[:ykill, :] *= 0.0
+        obj_data[-ykill:, :] *= 0.0
+        obj_var = obj_data + rdnoise**2
         # create fits hdu
-        hdu_name = 'VAR%d' % (i+1)
+        hdu_name = "VAR%d" % (i + 1)
         obj_hdu = pyfits.ImageHDU(obj_var, old_hdr, name=hdu_name)
-        obj_hdu.header.set('DETSEC',  obj_dim_str)
-        obj_hdu.header.set('DATASEC', obj_dim_str)
-        obj_hdu.header.set('TRIMSEC', obj_dim_str)
+        obj_hdu.header.set("DETSEC", obj_dim_str)
+        obj_hdu.header.set("DATASEC", obj_dim_str)
+        obj_hdu.header.set("TRIMSEC", obj_dim_str)
         # fix the exposure time!!
-        exptime_true = float(old_hdr['EXPTIME'])
-        obj_hdu.header.set('EXPTIME', exptime_true,
-                              comment='Total NS exposure time')
+        exptime_true = float(old_hdr["EXPTIME"])
+        obj_hdu.header.set("EXPTIME", exptime_true, comment="Total NS exposure time")
         outfits_obj.append(obj_hdu)
-        #------------------
+        # ------------------
         # get the sky data
-        sky_dim_str = '[%d:%d,%d:%d]' % (
-            sky_defs[0], sky_defs[1],
-            sky_defs[2], sky_defs[3])
-        sky_mod_defs = [sky_defs[0]-1, sky_defs[1],
-                        sky_defs[2]-1, sky_defs[3]]
-        nsx = sky_mod_defs[1]-sky_mod_defs[0]
-        nsy = sky_mod_defs[3]-sky_mod_defs[2]
+        sky_dim_str = "[%d:%d,%d:%d]" % (
+            sky_defs[0],
+            sky_defs[1],
+            sky_defs[2],
+            sky_defs[3],
+        )
+        sky_mod_defs = [sky_defs[0] - 1, sky_defs[1], sky_defs[2] - 1, sky_defs[3]]
+        nsx = sky_mod_defs[1] - sky_mod_defs[0]
+        nsy = sky_mod_defs[3] - sky_mod_defs[2]
         # horrible fix to include bad NS regions definition for slitlet 1
         sky_data = numpy.zeros([nsy, nsx])
-        true_sky_data = full_data[sky_mod_defs[2]:sky_mod_defs[3],
-                                  sky_mod_defs[0]:sky_mod_defs[1]]
+        true_sky_data = full_data[
+            sky_mod_defs[2] : sky_mod_defs[3], sky_mod_defs[0] : sky_mod_defs[1]
+        ]
         tsy, tsx = numpy.shape(true_sky_data)
-        sky_data[:tsy,:tsx] = true_sky_data
+        sky_data[:tsy, :tsx] = true_sky_data
         # kill outer 3//bin_y pixels!!
-        ykill = 4//bin_y
-        sky_data[:ykill,:]  *= 0.0
-        sky_data[-ykill:,:] *= 0.0
-        sky_var = sky_data+rdnoise**2
+        ykill = 4 // bin_y
+        sky_data[:ykill, :] *= 0.0
+        sky_data[-ykill:, :] *= 0.0
+        sky_var = sky_data + rdnoise**2
         # create fits hdu
-        hdu_name = 'VAR%d' % (i+1)
+        hdu_name = "VAR%d" % (i + 1)
         sky_hdu = pyfits.ImageHDU(sky_var, old_hdr, name=hdu_name)
-        sky_hdu.header.set('DETSEC',  sky_dim_str)
-        sky_hdu.header.set('DATASEC', sky_dim_str)
-        sky_hdu.header.set('TRIMSEC', sky_dim_str)
+        sky_hdu.header.set("DETSEC", sky_dim_str)
+        sky_hdu.header.set("DATASEC", sky_dim_str)
+        sky_hdu.header.set("TRIMSEC", sky_dim_str)
         # fix the exposure time!!
-        exptime_true = float(old_hdr['EXPTIME'])
-        sky_hdu.header.set('EXPTIME', exptime_true,
-                              comment='Total NS exposure time')
+        exptime_true = float(old_hdr["EXPTIME"])
+        sky_hdu.header.set("EXPTIME", exptime_true, comment="Total NS exposure time")
         outfits_sky.append(sky_hdu)
         gc.collect()
-    #------------------------------------
+    # ------------------------------------
     # DATA QUALITY EXTENSIONS
     for i in range(nslits):
-        init_curr_defs = slitlet_defs[str(i+1)]
-        #------------------
+        init_curr_defs = slitlet_defs[str(i + 1)]
+        # ------------------
         # convert to binned values
         obj_defs = [
-            ((init_curr_defs[0]-1)//bin_x)+1,
-            ((init_curr_defs[1]-1)//bin_x)+1,
-            ((init_curr_defs[2]-1)//bin_y)+1,
-            ((init_curr_defs[3]-1)//bin_y)+1]
+            ((init_curr_defs[0] - 1) // bin_x) + 1,
+            ((init_curr_defs[1] - 1) // bin_x) + 1,
+            ((init_curr_defs[2] - 1) // bin_y) + 1,
+            ((init_curr_defs[3] - 1) // bin_y) + 1,
+        ]
         sky_defs = [
-            ((init_curr_defs[0]-1)//bin_x)+1,
-            ((init_curr_defs[1]-1)//bin_x)+1,
-            ((init_curr_defs[2]-1+nod_dy)//bin_y)+1,
-            ((init_curr_defs[3]-1+nod_dy)//bin_y)+1]
-        #------------------
+            ((init_curr_defs[0] - 1) // bin_x) + 1,
+            ((init_curr_defs[1] - 1) // bin_x) + 1,
+            ((init_curr_defs[2] - 1 + nod_dy) // bin_y) + 1,
+            ((init_curr_defs[3] - 1 + nod_dy) // bin_y) + 1,
+        ]
+        # ------------------
         # horrible kluge to make sure everything has the same dimensions!
-        if (obj_defs[1]-obj_defs[0]+1) != (4096//bin_x):
+        if (obj_defs[1] - obj_defs[0] + 1) != (4096 // bin_x):
             obj_defs[1] -= 1
-        if (obj_defs[3]-obj_defs[2]+1) != (86//bin_y):
+        if (obj_defs[3] - obj_defs[2] + 1) != (86 // bin_y):
             obj_defs[3] -= 1
-        if (sky_defs[1]-sky_defs[0]+1) != (4096//bin_x):
+        if (sky_defs[1] - sky_defs[0] + 1) != (4096 // bin_x):
             sky_defs[1] -= 1
-        if (sky_defs[3]-sky_defs[2]+1) != (86//bin_y):
-            sky_defs[3] -= (sky_defs[3]-sky_defs[2]+1) - (86//bin_y)
-            #sky_defs[3] -= 1
-        #------------------
+        if (sky_defs[3] - sky_defs[2] + 1) != (86 // bin_y):
+            sky_defs[3] -= (sky_defs[3] - sky_defs[2] + 1) - (86 // bin_y)
+            # sky_defs[3] -= 1
+        # ------------------
         # get the data
-        obj_dim_str = '[%d:%d,%d:%d]' % (
-            obj_defs[0], obj_defs[1],
-            obj_defs[2], obj_defs[3])
-        sky_dim_str = '[%d:%d,%d:%d]' % (
-            sky_defs[0], sky_defs[1],
-            sky_defs[2], sky_defs[3])
-        nyo = obj_defs[3]-obj_defs[2]+1
-        nxo = obj_defs[1]-obj_defs[0]+1
-        nys = sky_defs[3]-sky_defs[2]+1
-        nxs = sky_defs[1]-sky_defs[0]+1
-        obj_dq = numpy.zeros([nyo,nxo])
-        sky_dq = numpy.zeros([nys,nxs])
-        #------------------
+        obj_dim_str = "[%d:%d,%d:%d]" % (
+            obj_defs[0],
+            obj_defs[1],
+            obj_defs[2],
+            obj_defs[3],
+        )
+        sky_dim_str = "[%d:%d,%d:%d]" % (
+            sky_defs[0],
+            sky_defs[1],
+            sky_defs[2],
+            sky_defs[3],
+        )
+        nyo = obj_defs[3] - obj_defs[2] + 1
+        nxo = obj_defs[1] - obj_defs[0] + 1
+        nys = sky_defs[3] - sky_defs[2] + 1
+        nxs = sky_defs[1] - sky_defs[0] + 1
+        obj_dq = numpy.zeros([nyo, nxo])
+        sky_dq = numpy.zeros([nys, nxs])
+        # ------------------
         # create fits hdu for object
-        hdu_name = 'DQ%d' % (i+1)
+        hdu_name = "DQ%d" % (i + 1)
         obj_hdu = pyfits.ImageHDU(obj_dq, old_hdr, name=hdu_name)
-        obj_hdu.header.set('DETSEC',  obj_dim_str)
-        obj_hdu.header.set('DATASEC', obj_dim_str)
-        obj_hdu.header.set('TRIMSEC', obj_dim_str)
+        obj_hdu.header.set("DETSEC", obj_dim_str)
+        obj_hdu.header.set("DATASEC", obj_dim_str)
+        obj_hdu.header.set("TRIMSEC", obj_dim_str)
         # fix the exposure time!!
-        exptime_true = float(old_hdr['EXPTIME'])
-        obj_hdu.header.set('EXPTIME', exptime_true,
-                              comment='Total NS exposure time')
+        exptime_true = float(old_hdr["EXPTIME"])
+        obj_hdu.header.set("EXPTIME", exptime_true, comment="Total NS exposure time")
         outfits_obj.append(obj_hdu)
-        #------------------
+        # ------------------
         # create fits hdu for object
-        hdu_name = 'DQ%d' % (i+1)
+        hdu_name = "DQ%d" % (i + 1)
         sky_hdu = pyfits.ImageHDU(sky_dq, old_hdr, name=hdu_name)
-        sky_hdu.header.set('DETSEC',  sky_dim_str)
-        sky_hdu.header.set('DATASEC', sky_dim_str)
-        sky_hdu.header.set('TRIMSEC', sky_dim_str)
+        sky_hdu.header.set("DETSEC", sky_dim_str)
+        sky_hdu.header.set("DATASEC", sky_dim_str)
+        sky_hdu.header.set("TRIMSEC", sky_dim_str)
         # fix the exposure time!!
-        exptime_true = float(old_hdr['EXPTIME'])
-        sky_hdu.header.set('EXPTIME', exptime_true,
-                              comment='Total NS exposure time')
+        exptime_true = float(old_hdr["EXPTIME"])
+        sky_hdu.header.set("EXPTIME", exptime_true, comment="Total NS exposure time")
         outfits_sky.append(sky_hdu)
         gc.collect()
-    #------------------------------------
-    outfits_obj[0].header.set('PYWIFES', __version__, 'PyWiFeS version')
-    outfits_sky[0].header.set('PYWIFES', __version__, 'PyWiFeS version')
+    # ------------------------------------
+    outfits_obj[0].header.set("PYWIFES", __version__, "PyWiFeS version")
+    outfits_sky[0].header.set("PYWIFES", __version__, "PyWiFeS version")
     outfits_obj.writeto(outimg_obj, overwrite=True)
     outfits_sky.writeto(outimg_sky, overwrite=True)
     return
 
-#------------------------------------------------------------------------
-def wifes_response_pixel(inimg, outimg, wsol_fn = None):
+
+# ------------------------------------------------------------------------
+def wifes_response_pixel(inimg, outimg, wsol_fn=None):
     # check if halfframe
     halfframe = is_halfframe(inimg)
     if halfframe:
@@ -2074,42 +2284,41 @@ def wifes_response_pixel(inimg, outimg, wsol_fn = None):
     f = pyfits.open(inimg)
     outfits = pyfits.HDUList(f)
     for i in range(nslits):
-        curr_hdu = i+1
+        curr_hdu = i + 1
         orig_data = f[curr_hdu].data
         # NEW 2012-04-20
         # rectify data!
         if wsol_fn != None:
             f3 = pyfits.open(wsol_fn)
-            wave = f3[i+1].data
+            wave = f3[i + 1].data
             f3.close()
-            print('Transforming data for Slitlet %d' % curr_hdu)
-            rect_data =  transform_data(orig_data, wave)
+            print("Transforming data for Slitlet %d" % curr_hdu)
+            rect_data = transform_data(orig_data, wave)
             curr_ff_rowwise_ave = numpy.median(rect_data, axis=0)
-            curr_ff_illum = numpy.median(rect_data/curr_ff_rowwise_ave,
-                                         axis=1)
-            curr_model = ((numpy.ones(numpy.shape(rect_data))
-                           *curr_ff_rowwise_ave).T*curr_ff_illum).T
-            orig_model = detransform_data(
-                curr_model, orig_data, wave)
+            curr_ff_illum = numpy.median(rect_data / curr_ff_rowwise_ave, axis=1)
+            curr_model = (
+                (numpy.ones(numpy.shape(rect_data)) * curr_ff_rowwise_ave).T
+                * curr_ff_illum
+            ).T
+            orig_model = detransform_data(curr_model, orig_data, wave)
             normed_data = orig_data / orig_model
         else:
             curr_ff_rowwise_ave = numpy.median(orig_data, axis=0)
-            curr_ff_illum = numpy.median(orig_data/curr_ff_rowwise_ave,
-                                         axis=1)
-            curr_model = ((numpy.ones(numpy.shape(orig_data))
-                           *curr_ff_rowwise_ave).T*curr_ff_illum).T
+            curr_ff_illum = numpy.median(orig_data / curr_ff_rowwise_ave, axis=1)
+            curr_model = (
+                (numpy.ones(numpy.shape(orig_data)) * curr_ff_rowwise_ave).T
+                * curr_ff_illum
+            ).T
             normed_data = orig_data / curr_model
         outfits[curr_hdu].data = normed_data
         # need to fit this for each slitlet
-    outfits[0].header.set('PYWIFES', __version__, 'PyWiFeS version')
+    outfits[0].header.set("PYWIFES", __version__, "PyWiFeS version")
     outfits.writeto(outimg, overwrite=True)
     f.close()
     return
 
-def wifes_response_poly(inimg, outimg,
-                        wsol_fn=None,
-                        zero_var=True,
-                        polydeg=7):
+
+def wifes_response_poly(inimg, outimg, wsol_fn=None, zero_var=True, polydeg=7):
     # check if halfframe
     halfframe = is_halfframe(inimg)
     if halfframe:
@@ -2121,92 +2330,83 @@ def wifes_response_poly(inimg, outimg,
     # now open and operate on data
     f = pyfits.open(inimg)
     outfits = pyfits.HDUList(f)
-    #------------------------------------
+    # ------------------------------------
     # fit a smooth polynomial to the middle slice
     midslice_data = f[mid_slit].data
     if wsol_fn != None:
         f3 = pyfits.open(wsol_fn)
         wave = f3[mid_slit].data
         f3.close()
-        rect_data, lam_array =  transform_data(
-            midslice_data, wave, return_lambda=True)
+        rect_data, lam_array = transform_data(midslice_data, wave, return_lambda=True)
     else:
         rect_data = midslice_data
-        lam_array = numpy.arange(len(rect_data[0,:]),dtype='d')
+        lam_array = numpy.arange(len(rect_data[0, :]), dtype="d")
     # fit polynomial to median data
     curr_ff_rowwise_ave = numpy.median(rect_data, axis=0)
     curr_y = numpy.log10(curr_ff_rowwise_ave)
-    good_inds = numpy.nonzero((curr_y == curr_y)*
-                              (curr_ff_rowwise_ave > 0.0))[0]
+    good_inds = numpy.nonzero((curr_y == curr_y) * (curr_ff_rowwise_ave > 0.0))[0]
     # add points far away to force edge derivatives to be preserved
     next_x = lam_array[good_inds][5:-5]
     next_y = curr_y[good_inds][5:-5]
-    yderiv = (next_y[1:]-next_y[:-1])/(next_x[1:]-next_x[:-1])
+    yderiv = (next_y[1:] - next_y[:-1]) / (next_x[1:] - next_x[:-1])
     nave_lo = 50
     nave_hi = 100
     nextend_lo = 150.0
     nextend_hi = 300.0
     ydave_lo = numpy.mean(yderiv[:nave_lo])
     ydave_hi = numpy.mean(yderiv[-nave_hi:])
-    dxlo = numpy.arange(1,nextend_lo+1,dtype='d')*(next_x[1]-next_x[0])
+    dxlo = numpy.arange(1, nextend_lo + 1, dtype="d") * (next_x[1] - next_x[0])
     new_xlo = next_x[0] - dxlo
-    new_ylo = next_y[0] - dxlo*ydave_lo
-    dxhi = numpy.arange(1,nextend_hi+1,dtype='d')*(next_x[-1]-next_x[-2])
+    new_ylo = next_y[0] - dxlo * ydave_lo
+    dxhi = numpy.arange(1, nextend_hi + 1, dtype="d") * (next_x[-1] - next_x[-2])
     new_xhi = next_x[-1] + dxhi
-    new_yhi = next_y[-1] + dxhi*ydave_hi
-    fit_x = numpy.concatenate((
-        new_xlo,
-        next_x,
-        new_xhi))
-    fit_y = numpy.concatenate((
-        new_ylo,
-        next_y,
-        new_yhi))
+    new_yhi = next_y[-1] + dxhi * ydave_hi
+    fit_x = numpy.concatenate((new_xlo, next_x, new_xhi))
+    fit_y = numpy.concatenate((new_ylo, next_y, new_yhi))
     smooth_poly = numpy.polyfit(fit_x, fit_y, polydeg)
-    #------------------------------------
+    # ------------------------------------
     # divide rectified data by the smooth polynomial
     for i in range(nslits):
-        curr_hdu = i+1
+        curr_hdu = i + 1
         orig_data = f[curr_hdu].data
         # NEW 2012-04-20
         # rectify data!
         if wsol_fn != None:
             f3 = pyfits.open(wsol_fn)
-            wave = f3[i+1].data
+            wave = f3[i + 1].data
             f3.close()
-            print('Transforming data for Slitlet %d' % curr_hdu)
-            rect_data, lam_array =  transform_data(
-                orig_data, wave, return_lambda=True)
-            curr_norm_array = 10.0**(numpy.polyval(smooth_poly,
-                                                   lam_array))
+            print("Transforming data for Slitlet %d" % curr_hdu)
+            rect_data, lam_array = transform_data(orig_data, wave, return_lambda=True)
+            curr_norm_array = 10.0 ** (numpy.polyval(smooth_poly, lam_array))
             init_normed_data = rect_data / curr_norm_array
-            normed_data = detransform_data(
-                init_normed_data, orig_data, wave)
+            normed_data = detransform_data(init_normed_data, orig_data, wave)
         else:
-            lam_array = numpy.arange(len(orig_data[0,:]),dtype='d')
-            curr_norm_array = 10.0**(numpy.polyval(smooth_poly,
-                                                   lam_array))
+            lam_array = numpy.arange(len(orig_data[0, :]), dtype="d")
+            curr_norm_array = 10.0 ** (numpy.polyval(smooth_poly, lam_array))
             normed_data = rect_data / curr_norm_array
         outfits[curr_hdu].data = normed_data
         if zero_var:
-            var_hdu = curr_hdu+25
+            var_hdu = curr_hdu + 25
             outfits[var_hdu].data *= 0.0
         # need to fit this for each slitlet
-    outfits[0].header.set('PYWIFES', __version__, 'PyWiFeS version')
+    outfits[0].header.set("PYWIFES", __version__, "PyWiFeS version")
     outfits.writeto(outimg, overwrite=True)
     f.close()
     return
 
-def wifes_2dim_response(spec_inimg,
-                        spatial_inimg,
-                        outimg,
-                        wsol_fn=None,
-                        zero_var=True,
-                        plot=False,
-                        savefigs=False,
-                        save_prefix='response_',
-                        polydeg=7,
-                        resp_min=1.0e-6):
+
+def wifes_2dim_response(
+    spec_inimg,
+    spatial_inimg,
+    outimg,
+    wsol_fn=None,
+    zero_var=True,
+    plot=False,
+    savefigs=False,
+    save_prefix="response_",
+    polydeg=7,
+    resp_min=1.0e-6,
+):
     # check if halfframe
     halfframe = is_halfframe(spec_inimg)
     if halfframe:
@@ -2224,7 +2424,7 @@ def wifes_2dim_response(spec_inimg,
     full_x, full_y = numpy.meshgrid(xarr, yarr)
     all_ypos_flat = full_y.flatten()
     outfits = pyfits.HDUList(f1)
-    #------------------------------------
+    # ------------------------------------
     # SPECTRAL FLAT
     # fit a smooth polynomial to the middle slice
     midslice_data = f1[mid_slit].data
@@ -2232,48 +2432,42 @@ def wifes_2dim_response(spec_inimg,
         f3 = pyfits.open(wsol_fn)
         wave = f3[mid_slit].data
         f3.close()
-        rect_data, mid_lam_array =  transform_data(
-            midslice_data, wave, return_lambda=True)
+        rect_data, mid_lam_array = transform_data(
+            midslice_data, wave, return_lambda=True
+        )
     else:
         rect_data = midslice_data
-        mid_lam_array = numpy.arange(len(rect_data[0,:]),dtype='d')
+        mid_lam_array = numpy.arange(len(rect_data[0, :]), dtype="d")
     out_y_full, out_lambda_full = numpy.meshgrid(yarr, mid_lam_array)
-    disp_ave = abs(numpy.mean(mid_lam_array[1:]-mid_lam_array[:-1]))
+    disp_ave = abs(numpy.mean(mid_lam_array[1:] - mid_lam_array[:-1]))
     # fit polynomial to median data
     curr_ff_rowwise_ave = numpy.median(rect_data, axis=0)
     curr_y = numpy.log10(curr_ff_rowwise_ave)
-    good_inds = numpy.nonzero((curr_y == curr_y)*
-                              (curr_ff_rowwise_ave > 0.0))[0]
+    good_inds = numpy.nonzero((curr_y == curr_y) * (curr_ff_rowwise_ave > 0.0))[0]
     # add points far away to force edge derivatives to be preserved
-    if pyfits.getval(spec_inimg, 'CAMERA') == 'WiFeSRed':
+    if pyfits.getval(spec_inimg, "CAMERA") == "WiFeSRed":
         next_x = mid_lam_array[good_inds][500:-10]
         next_y = curr_y[good_inds][500:-10]
     else:
         next_x = mid_lam_array[good_inds][50:-100]
         next_y = curr_y[good_inds][50:-100]
-    yderiv = (next_y[1:]-next_y[:-1])/(next_x[1:]-next_x[:-1])
+    yderiv = (next_y[1:] - next_y[:-1]) / (next_x[1:] - next_x[:-1])
     nave_lo = 50
     nave_hi = 100
     nextend_lo = 150.0
     nextend_hi = 300.0
     ydave_lo = numpy.mean(yderiv[:nave_lo])
     ydave_hi = numpy.mean(yderiv[-nave_hi:])
-    dxlo = numpy.arange(1,nextend_lo+1,dtype='d')*(next_x[1]-next_x[0])
+    dxlo = numpy.arange(1, nextend_lo + 1, dtype="d") * (next_x[1] - next_x[0])
     new_xlo = next_x[0] - dxlo
-    new_ylo = next_y[0] - dxlo*ydave_lo
-    dxhi = numpy.arange(1,nextend_hi+1,dtype='d')*(next_x[-1]-next_x[-2])
+    new_ylo = next_y[0] - dxlo * ydave_lo
+    dxhi = numpy.arange(1, nextend_hi + 1, dtype="d") * (next_x[-1] - next_x[-2])
     new_xhi = next_x[-1] + dxhi
-    new_yhi = next_y[-1] + dxhi*ydave_hi
-    fit_x = numpy.concatenate((
-        new_xlo,
-        next_x,
-        new_xhi))
-    fit_y = numpy.concatenate((
-        new_ylo,
-        next_y,
-        new_yhi))
+    new_yhi = next_y[-1] + dxhi * ydave_hi
+    fit_x = numpy.concatenate((new_xlo, next_x, new_xhi))
+    fit_y = numpy.concatenate((new_ylo, next_y, new_yhi))
     smooth_poly = numpy.polyfit(fit_x, fit_y, polydeg)
-    #------------------------------------
+    # ------------------------------------
     # SPATIAL FLAT
     # get median spatial flat spectrum
     midslice_data = f2[mid_slit].data
@@ -2281,148 +2475,144 @@ def wifes_2dim_response(spec_inimg,
         f3 = pyfits.open(wsol_fn)
         wave = f3[mid_slit].data
         f3.close()
-        rect_data =  transform_data(
-            midslice_data, wave)
+        rect_data = transform_data(midslice_data, wave)
     else:
         rect_data = midslice_data
     # fit polynomial to median data
     spatial_flat_spec = numpy.median(rect_data, axis=0)
     spec_norm = curr_ff_rowwise_ave / (
-        10.0**(numpy.polyval(smooth_poly, mid_lam_array)))
-    #pylab.figure()
-    #pylab.plot(mid_lam_array, spec_norm)
-    #pylab.show()
+        10.0 ** (numpy.polyval(smooth_poly, mid_lam_array))
+    )
+    # pylab.figure()
+    # pylab.plot(mid_lam_array, spec_norm)
+    # pylab.show()
     spat_interp = scipy.interpolate.interp1d(
-        mid_lam_array, spatial_flat_spec/spec_norm,
-        bounds_error=False,
-        fill_value=0.0)
-    #------------------------------------
-    #------------------------------------
-    illum = numpy.zeros([ndy, 25], dtype='d')
+        mid_lam_array, spatial_flat_spec / spec_norm, bounds_error=False, fill_value=0.0
+    )
+    # ------------------------------------
+    # ------------------------------------
+    illum = numpy.zeros([ndy, 25], dtype="d")
     # divide rectified data by the smooth polynomial
     for i in range(nslits):
-        curr_hdu = i+1
+        curr_hdu = i + 1
         orig_spec_data = f1[curr_hdu].data
         orig_spat_data = f2[curr_hdu].data
         # NEW 2012-04-20
         # rectify data!
         if wsol_fn != None:
             f3 = pyfits.open(wsol_fn)
-            wave = f3[i+1].data
+            wave = f3[i + 1].data
             f3.close()
             # convert the *x* pixels to lambda
-            dw = numpy.abs(wave[:,1:]-wave[:,:-1])
+            dw = numpy.abs(wave[:, 1:] - wave[:, :-1])
             full_dw = numpy.zeros(numpy.shape(wave))
-            full_dw[:,1:] = dw
-            full_dw[:,0] = dw[:,0]
-            print('Transforming data for Slitlet %d' % curr_hdu)
+            full_dw[:, 1:] = dw
+            full_dw[:, 0] = dw[:, 0]
+            print("Transforming data for Slitlet %d" % curr_hdu)
             # SPECTRAL FLAT
-            rect_spec_data, lam_array =  transform_data(
-                orig_spec_data, wave, return_lambda=True)
-            curr_norm_array = 10.0**(numpy.polyval(smooth_poly,
-                                                   lam_array))
+            rect_spec_data, lam_array = transform_data(
+                orig_spec_data, wave, return_lambda=True
+            )
+            curr_norm_array = 10.0 ** (numpy.polyval(smooth_poly, lam_array))
             init_normed_data = rect_spec_data / curr_norm_array
-            xstart = int(0.25*len(lam_array))
-            xstop  = int(0.75*len(lam_array))
-            norm_region = init_normed_data[:,xstart:xstop]
-            next_normed_data = (init_normed_data.T/
-                                numpy.median(norm_region,axis=1)).T
+            xstart = int(0.25 * len(lam_array))
+            xstop = int(0.75 * len(lam_array))
+            norm_region = init_normed_data[:, xstart:xstop]
+            next_normed_data = (
+                init_normed_data.T / numpy.median(norm_region, axis=1)
+            ).T
             # SPATIAL FLAT
-            rect_spat_data =  transform_data(
-                orig_spat_data, wave, return_lambda=False)
-            alt_dw = lam_array[1]-lam_array[0]
+            rect_spat_data = transform_data(orig_spat_data, wave, return_lambda=False)
+            alt_dw = lam_array[1] - lam_array[0]
             alt_flat_spec = spat_interp(lam_array)
-            curr_interp_spat = numpy.zeros(numpy.shape(out_y_full),
-                                           dtype='d')
-            alt_interp_spat = numpy.zeros(numpy.shape(rect_spat_data),
-                                          dtype='d')
-            #f1 = pylab.figure()
-            #sp1 = f1.add_subplot(111)
-            #pylab.title(str(curr_hdu))
-            #f2 = pylab.figure()
-            #sp2 = f2.add_subplot(111)
+            curr_interp_spat = numpy.zeros(numpy.shape(out_y_full), dtype="d")
+            alt_interp_spat = numpy.zeros(numpy.shape(rect_spat_data), dtype="d")
+            # f1 = pylab.figure()
+            # sp1 = f1.add_subplot(111)
+            # pylab.title(str(curr_hdu))
+            # f2 = pylab.figure()
+            # sp2 = f2.add_subplot(111)
             for q in range(ndy):
-                curr_x = wave[q,:]
-                curr_y = orig_spat_data[q,:]/full_dw[q,:]
+                curr_x = wave[q, :]
+                curr_y = orig_spat_data[q, :] / full_dw[q, :]
                 sort_order = curr_x.argsort()
                 curr_interp = scipy.interpolate.interp1d(
-                    curr_x[sort_order], curr_y[sort_order],
+                    curr_x[sort_order],
+                    curr_y[sort_order],
                     bounds_error=False,
-                    fill_value=0.0)
-                new_data = disp_ave*curr_interp(mid_lam_array)
-                curr_interp_spat[:,q] = new_data
-                #norm_func = (new_data / spatial_flat_spec)
-                alt_y = rect_spat_data[q,:]
-                norm_func = (alt_y / (
-                    alt_flat_spec*next_normed_data[q,:]))
-                alt_interp_spat[q,:] = norm_func
-                #print len(new_data)
-                #print len(norm_func)
-                #norm_func = (alt_y / (
+                    fill_value=0.0,
+                )
+                new_data = disp_ave * curr_interp(mid_lam_array)
+                curr_interp_spat[:, q] = new_data
+                # norm_func = (new_data / spatial_flat_spec)
+                alt_y = rect_spat_data[q, :]
+                norm_func = alt_y / (alt_flat_spec * next_normed_data[q, :])
+                alt_interp_spat[q, :] = norm_func
+                # print len(new_data)
+                # print len(norm_func)
+                # norm_func = (alt_y / (
                 #    alt_flat_spec))
-                #sp1.plot(norm_func[500:-200])
-                #sp2.plot(next_normed_data[q,:])
-            #pylab.show()
-            #spat_ratio = curr_interp_spat.T / spatial_flat_spec
+                # sp1.plot(norm_func[500:-200])
+                # sp2.plot(next_normed_data[q,:])
+            # pylab.show()
+            # spat_ratio = curr_interp_spat.T / spatial_flat_spec
             spat_ratio = alt_interp_spat
-            spat_ratio[numpy.nonzero(spat_ratio!=spat_ratio)] = 0.0
-            spat_ratio[numpy.nonzero(spat_ratio<0.0)] = 0.0
-            spat_flat = numpy.median(spat_ratio[:,xstart:xstop], axis=1)
+            spat_ratio[numpy.nonzero(spat_ratio != spat_ratio)] = 0.0
+            spat_ratio[numpy.nonzero(spat_ratio < 0.0)] = 0.0
+            spat_flat = numpy.median(spat_ratio[:, xstart:xstop], axis=1)
             # transform back
-            final_normed_data = (next_normed_data.T*spat_flat).T
-            normed_data = detransform_data(
-                final_normed_data, orig_spec_data, wave)
+            final_normed_data = (next_normed_data.T * spat_flat).T
+            normed_data = detransform_data(final_normed_data, orig_spec_data, wave)
             normed_data[numpy.nonzero(normed_data <= resp_min)] = resp_min
         else:
-            lam_array = numpy.arange(len(orig_spec_data[0,:]),dtype='d')
-            curr_norm_array = 10.0**(numpy.polyval(smooth_poly,
-                                                   lam_array))
+            lam_array = numpy.arange(len(orig_spec_data[0, :]), dtype="d")
+            curr_norm_array = 10.0 ** (numpy.polyval(smooth_poly, lam_array))
             normed_data = orig_spec_data / curr_norm_array
         outfits[curr_hdu].data = normed_data
-        illum[:,i] = numpy.sum(normed_data, axis=1)
+        illum[:, i] = numpy.sum(normed_data, axis=1)
         if zero_var:
-            var_hdu = curr_hdu+25
+            var_hdu = curr_hdu + 25
             outfits[var_hdu].data *= 0.0
         # need to fit this for each slitlet
-    outfits[0].header.set('PYWIFES', __version__, 'PyWiFeS version')
+    outfits[0].header.set("PYWIFES", __version__, "PyWiFeS version")
     outfits.writeto(outimg, overwrite=True)
     f1.close()
     f2.close()
-    #---------------------------------------------
+    # ---------------------------------------------
     # diagnostic plots!
     if plot or savefigs:
-        #------------------
+        # ------------------
         # (1) spectral fit
         pylab.figure()
-        pylab.plot(mid_lam_array, curr_ff_rowwise_ave, 'b')
-        pylab.plot(mid_lam_array,
-                   10.0**(numpy.polyval(smooth_poly, mid_lam_array)),
-                   color='g', lw=3)
+        pylab.plot(mid_lam_array, curr_ff_rowwise_ave, "b")
+        pylab.plot(
+            mid_lam_array,
+            10.0 ** (numpy.polyval(smooth_poly, mid_lam_array)),
+            color="g",
+            lw=3,
+        )
         if savefigs:
-            save_fn = save_prefix+'flat_spectrum.png'
+            save_fn = save_prefix + "flat_spectrum.png"
             pylab.savefig(save_fn)
-        #------------------
+        # ------------------
         # (2) illumination correction
         pylab.figure()
-        pylab.imshow(illum,
-                     interpolation='nearest',
-                     origin='lower',
-                     cmap=pylab.cm.Greys_r)
+        pylab.imshow(
+            illum, interpolation="nearest", origin="lower", cmap=pylab.cm.Greys_r
+        )
         if savefigs:
-            save_fn = save_prefix+'flat_illumination.png'
+            save_fn = save_prefix + "flat_illumination.png"
             pylab.savefig(save_fn)
-        #------------------
+        # ------------------
         if plot:
             pylab.show()
-    #---------------------------------------------
+    # ---------------------------------------------
     return
 
-def wifes_illumination(spatial_inimg,
-                       outimg,
-                       wsol_fn=None,
-                       zero_var=True,
-                       polydeg=7,
-                       resp_min=1.0e-6):
+
+def wifes_illumination(
+    spatial_inimg, outimg, wsol_fn=None, zero_var=True, polydeg=7, resp_min=1.0e-6
+):
     # check if halfframe
     halfframe = is_halfframe(spatial_inimg)
     if halfframe:
@@ -2434,13 +2624,13 @@ def wifes_illumination(spatial_inimg,
     # open the two files!
     f2 = pyfits.open(spatial_inimg)
     ndy, ndx = numpy.shape(f2[1].data)
-    flat_ones = numpy.ones([ndy, ndx], dtype='d')
+    flat_ones = numpy.ones([ndy, ndx], dtype="d")
     xarr = numpy.arange(ndx)
     yarr = numpy.arange(ndy)
     full_x, full_y = numpy.meshgrid(xarr, yarr)
     all_ypos_flat = full_y.flatten()
     outfits = pyfits.HDUList(f2)
-    #------------------------------------
+    # ------------------------------------
     # SPATIAL FLAT
     # get median spatial flat spectrum
     midslice_data = f2[mid_slit].data
@@ -2448,104 +2638,112 @@ def wifes_illumination(spatial_inimg,
         f3 = pyfits.open(wsol_fn)
         wave = f3[mid_slit].data
         f3.close()
-        rect_data, mid_lam_array =  transform_data(
-            midslice_data, wave, return_lambda=True)
+        rect_data, mid_lam_array = transform_data(
+            midslice_data, wave, return_lambda=True
+        )
     else:
         rect_data = midslice_data
-        mid_lam_array = numpy.arange(len(rect_data[0,:]),dtype='d')
+        mid_lam_array = numpy.arange(len(rect_data[0, :]), dtype="d")
     out_y_full, out_lambda_full = numpy.meshgrid(yarr, mid_lam_array)
     # derive median data
     spatial_flat_spec = numpy.median(rect_data, axis=0)
-    #------------------------------------
-    #------------------------------------
+    # ------------------------------------
+    # ------------------------------------
     # divide rectified data by the smooth polynomial
     for i in range(nslits):
-        curr_hdu = i+1
+        curr_hdu = i + 1
         orig_spat_data = f2[curr_hdu].data
         # NEW 2012-04-20
         # rectify data!
         if wsol_fn != None:
             f3 = pyfits.open(wsol_fn)
-            wave = f3[i+1].data
+            wave = f3[i + 1].data
             f3.close()
-            print('Transforming data for Slitlet %d' % curr_hdu)
+            print("Transforming data for Slitlet %d" % curr_hdu)
             # SPATIAL FLAT
             wave_flat = wave.flatten()
-            dw = wave[:,1:]-wave[:,:-1]
+            dw = wave[:, 1:] - wave[:, :-1]
             full_dw = numpy.zeros(numpy.shape(wave))
-            full_dw[:,1:] = dw
-            full_dw[:,0] = dw[:,0]
+            full_dw[:, 1:] = dw
+            full_dw[:, 0] = dw[:, 0]
             wdisp = numpy.mean(dw)
             new_flux = orig_spat_data
-            curr_flux_flat = (new_flux/full_dw).flatten()
-            curr_interp_spat = wdisp*scipy.interpolate.griddata(
+            curr_flux_flat = (new_flux / full_dw).flatten()
+            curr_interp_spat = wdisp * scipy.interpolate.griddata(
                 (wave_flat, all_ypos_flat),
                 curr_flux_flat,
                 (out_lambda_full, out_y_full),
-                method='linear',
-                fill_value=0.0)
+                method="linear",
+                fill_value=0.0,
+            )
             spat_ratio = curr_interp_spat.T / spatial_flat_spec
-            spat_ratio[numpy.nonzero(spat_ratio!=spat_ratio)] = 0.0
-            spat_ratio[numpy.nonzero(spat_ratio<0.0)] = 0.0
+            spat_ratio[numpy.nonzero(spat_ratio != spat_ratio)] = 0.0
+            spat_ratio[numpy.nonzero(spat_ratio < 0.0)] = 0.0
             spat_flat = numpy.median(spat_ratio, axis=1)
         else:
-            spat_flat = (numpy.sum(orig_spat_data, axis=1)
-                         /numpy.sum(spatial_flat_spec))
-        spat_flat[numpy.nonzero(spat_flat < resp_min)[0]] = resp_min    
-        normed_data = (flat_ones.T*spat_flat).T
+            spat_flat = numpy.sum(orig_spat_data, axis=1) / numpy.sum(spatial_flat_spec)
+        spat_flat[numpy.nonzero(spat_flat < resp_min)[0]] = resp_min
+        normed_data = (flat_ones.T * spat_flat).T
         outfits[curr_hdu].data = normed_data
         if zero_var:
-            var_hdu = curr_hdu+25
+            var_hdu = curr_hdu + 25
             outfits[var_hdu].data *= 0.0
         # need to fit this for each slitlet
-    outfits[0].header.set('PYWIFES', __version__, 'PyWiFeS version')
+    outfits[0].header.set("PYWIFES", __version__, "PyWiFeS version")
     outfits.writeto(outimg, overwrite=True)
     f2.close()
     return
 
-#------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------
 # function to fit the wire solution!
-def derive_wifes_wire_solution(inimg, out_file,
-                               bin_x=None, bin_y=None,
-                               #fit_zones=[10,30,45,65],
-                               fit_zones=[16,26,54,70],
-                               flux_threshold=20,
-                               wire_polydeg=1,
-                               xlims='default'):
+def derive_wifes_wire_solution(
+    inimg,
+    out_file,
+    bin_x=None,
+    bin_y=None,
+    # fit_zones=[10,30,45,65],
+    fit_zones=[16, 26, 54, 70],
+    flux_threshold=20,
+    wire_polydeg=1,
+    xlims="default",
+):
     # note: later have these parameters as user-input kwargs
     # SOME PARAMTERS FOR THE FITTING
     init_nave = 10
     bg_polydeg = 3
     ctr_polydeg = 15
-    xlim_defaults = {'U7000' : [1,2500],
-                     'B7000' : [1,4096],
-                     'R7000' : [1000,3000],
-                     'I7000' : [1,4096],
-                     'B3000' : [1,2600],
-                     'R3000' : [850,4096]}
+    xlim_defaults = {
+        "U7000": [1, 2500],
+        "B7000": [1, 4096],
+        "R7000": [1000, 3000],
+        "I7000": [1, 4096],
+        "B3000": [1, 2600],
+        "R3000": [850, 4096],
+    }
     # define region for fitting light profile
     init_fit_pmin_1 = fit_zones[0]
     init_fit_pmax_1 = fit_zones[1]
     init_fit_pmin_2 = fit_zones[2]
     init_fit_pmax_2 = fit_zones[3]
-    #------------------------------------
+    # ------------------------------------
     f = pyfits.open(inimg)
     # check if it is halfframe
     halfframe = is_halfframe(inimg)
     if halfframe:
         nslits = 12
     else:
-        nslits = 25    
+        nslits = 25
     # figure out which channel it is
-    if f[1].header['CAMERA'] == 'WiFeSRed':
-        channel = 'red'
-        grating = f[1].header['GRATINGR']
+    if f[1].header["CAMERA"] == "WiFeSRed":
+        channel = "red"
+        grating = f[1].header["GRATINGR"]
     else:
-        channel = 'blue'    
-        grating = f[1].header['GRATINGB']
+        channel = "blue"
+        grating = f[1].header["GRATINGB"]
     # figure out the binning!
     try:
-        bin_temp = f[1].header['CCDSUM'].split()
+        bin_temp = f[1].header["CCDSUM"].split()
         default_bin_x = int(float(bin_temp[0]))
         default_bin_y = int(float(bin_temp[1]))
     except:
@@ -2556,37 +2754,36 @@ def derive_wifes_wire_solution(inimg, out_file,
     if bin_y == None:
         bin_y = default_bin_y
     # get the xmax for fitting if default selected
-    if xlims == 'default':
-        xmin = (xlim_defaults[grating][0]-1)//bin_x
-        xmax = (xlim_defaults[grating][1]-1)//bin_x
+    if xlims == "default":
+        xmin = (xlim_defaults[grating][0] - 1) // bin_x
+        xmax = (xlim_defaults[grating][1] - 1) // bin_x
     else:
         xmin = xlims[0]
         xmax = xlims[1]
     # adjust the fit regions accordingly
-    nave = init_nave//bin_x
-    fit_pmin_1 = init_fit_pmin_1//bin_y
-    fit_pmax_1 = init_fit_pmax_1//bin_y
-    fit_pmin_2 = init_fit_pmin_2//bin_y
-    fit_pmax_2 = init_fit_pmax_2//bin_y
-    #------------------------------------
+    nave = init_nave // bin_x
+    fit_pmin_1 = init_fit_pmin_1 // bin_y
+    fit_pmax_1 = init_fit_pmax_1 // bin_y
+    fit_pmin_2 = init_fit_pmin_2 // bin_y
+    fit_pmax_2 = init_fit_pmax_2 // bin_y
+    # ------------------------------------
     # get data size and set up output data array
     temp_data = f[1].data
     ny, nx = numpy.shape(temp_data)
-    ctr_results = numpy.zeros([25,nx],dtype='f')
-    ccd_x = numpy.arange(nx,dtype='f')
+    ctr_results = numpy.zeros([25, nx], dtype="f")
+    ccd_x = numpy.arange(nx, dtype="f")
     # number of groupings to do
-    ng = nx//nave - 1
+    ng = nx // nave - 1
     for q in range(nslits):
-        slit_ind = q+1
-        #print slit_ind
+        slit_ind = q + 1
+        # print slit_ind
         test_data = f[slit_ind].data
         nr, junk = numpy.shape(test_data)
         fit_inds = numpy.nonzero(
-            ((numpy.arange(nr) >= fit_pmin_1)*
-             (numpy.arange(nr) <= fit_pmax_1))+
-            ((numpy.arange(nr) >= fit_pmin_2)*
-             (numpy.arange(nr) <= fit_pmax_2)))[0]
-        x_full = numpy.arange(nr,dtype='d')
+            ((numpy.arange(nr) >= fit_pmin_1) * (numpy.arange(nr) <= fit_pmax_1))
+            + ((numpy.arange(nr) >= fit_pmin_2) * (numpy.arange(nr) <= fit_pmax_2))
+        )[0]
+        x_full = numpy.arange(nr, dtype="d")
         x_fit = x_full[fit_inds]
         ##initializing at zero on the following line means that the frame_fit_y[-1] works in the first group
         ##but will be excluded by the xlims later, as long as the xmin is always > 0
@@ -2595,104 +2792,136 @@ def derive_wifes_wire_solution(inimg, out_file,
         for i in range(ng):
             # get median profile
             yprof = numpy.median(
-                test_data[:,numpy.max([0,nave*i-nave//2]):numpy.min([nave*i+nave//2,test_data.shape[1]])+1],axis=1)
+                test_data[
+                    :,
+                    numpy.max([0, nave * i - nave // 2]) : numpy.min(
+                        [nave * i + nave // 2, test_data.shape[1]]
+                    )
+                    + 1,
+                ],
+                axis=1,
+            )
             # if there is no usable data, use previous value!
             if numpy.max(yprof) < flux_threshold:
                 wire_ctr = frame_fit_y[-1]
             # otherwise fit the region outside of ~[30:50]
             else:
                 curr_fit = numpy.polyfit(
-                    x_fit,
-                    numpy.log10(yprof[fit_inds]),
-                    bg_polydeg)
-                curr_fvals = 10.0**(numpy.polyval(curr_fit, x_full))
+                    x_fit, numpy.log10(yprof[fit_inds]), bg_polydeg
+                )
+                curr_fvals = 10.0 ** (numpy.polyval(curr_fit, x_full))
                 # now take residuals and calculate a simple centroid
-                wire_x = numpy.arange(fit_pmin_1,fit_pmax_2)
-                wire_y = (curr_fvals-yprof)[fit_pmin_1:fit_pmax_2]
-                wire_ctr = single_centroid_prof_fit(wire_y,x=wire_x)
-            frame_fit_x.append(float(nave*i))
+                wire_x = numpy.arange(fit_pmin_1, fit_pmax_2)
+                wire_y = (curr_fvals - yprof)[fit_pmin_1:fit_pmax_2]
+                wire_ctr = single_centroid_prof_fit(wire_y, x=wire_x)
+            frame_fit_x.append(float(nave * i))
             frame_fit_y.append(wire_ctr)
         fit_x_arr = numpy.array(frame_fit_x)
         fit_y_arr = numpy.array(frame_fit_y)
-        good_inds = numpy.nonzero((fit_x_arr==fit_x_arr)*
-                                  (fit_y_arr==fit_y_arr)*
-                                  (fit_x_arr>=xmin)*
-                                  (fit_x_arr<=xmax))[0]
-        wire_trend = numpy.polyfit(fit_x_arr[good_inds],
-                                   fit_y_arr[good_inds],
-                                   wire_polydeg)
+        good_inds = numpy.nonzero(
+            (fit_x_arr == fit_x_arr)
+            * (fit_y_arr == fit_y_arr)
+            * (fit_x_arr >= xmin)
+            * (fit_x_arr <= xmax)
+        )[0]
+        wire_trend = numpy.polyfit(
+            fit_x_arr[good_inds], fit_y_arr[good_inds], wire_polydeg
+        )
         trend_y = numpy.polyval(wire_trend, ccd_x)
-        #pylab.figure()
-        #pylab.plot(fit_x_arr, fit_y_arr, 'b')
-        #pylab.plot(ccd_x, trend_y, 'r')
-        #pylab.show()
-        ctr_results[q,:] = trend_y
+        # pylab.figure()
+        # pylab.plot(fit_x_arr, fit_y_arr, 'b')
+        # pylab.plot(ccd_x, trend_y, 'r')
+        # pylab.show()
+        ctr_results[q, :] = trend_y
     f.close()
-    results = pyfits.PrimaryHDU(data = ctr_results)
+    results = pyfits.PrimaryHDU(data=ctr_results)
     g = pyfits.HDUList([results])
-    g[0].header.set('PYWIFES', __version__, 'PyWiFeS version')
+    g[0].header.set("PYWIFES", __version__, "PyWiFeS version")
     g.writeto(out_file, overwrite=True)
     return
 
-#-------------------------------------------------------------
+
+# -------------------------------------------------------------
 # DATA CUBE!!!
-def generate_wifes_cube(inimg, outimg,
-                        wire_fn,
-                        wsol_fn,
-                        wmin_set = None, wmax_set = None,dw_set = None,
-                        bin_x=None, bin_y=None,
-                        ny_orig=76,
-                        offset_orig=4,
-                        multithread=False,
-                        max_processes=-1,
-                        verbose=True,
-                        adr=False):
+def generate_wifes_cube(
+    inimg,
+    outimg,
+    wire_fn,
+    wsol_fn,
+    wmin_set=None,
+    wmax_set=None,
+    dw_set=None,
+    bin_x=None,
+    bin_y=None,
+    ny_orig=76,
+    offset_orig=4,
+    multithread=False,
+    max_processes=-1,
+    verbose=True,
+    adr=False,
+):
     if multithread:
         generate_wifes_cube_multithread(
-            inimg, outimg,
+            inimg,
+            outimg,
             wire_fn,
             wsol_fn,
-            wmin_set = wmin_set, wmax_set = wmax_set,dw_set=dw_set,
-            bin_x=bin_x, bin_y=bin_y,
+            wmin_set=wmin_set,
+            wmax_set=wmax_set,
+            dw_set=dw_set,
+            bin_x=bin_x,
+            bin_y=bin_y,
             ny_orig=ny_orig,
             offset_orig=offset_orig,
             max_processes=max_processes,
             verbose=verbose,
-            adr=adr)
+            adr=adr,
+        )
     else:
         generate_wifes_cube_oneproc(
-            inimg, outimg,
+            inimg,
+            outimg,
             wire_fn,
             wsol_fn,
-            wmin_set = wmin_set, wmax_set = wmax_set, dw_set = dw_set,
-            bin_x=bin_x, bin_y=bin_y,
+            wmin_set=wmin_set,
+            wmax_set=wmax_set,
+            dw_set=dw_set,
+            bin_x=bin_x,
+            bin_y=bin_y,
             ny_orig=ny_orig,
             offset_orig=offset_orig,
             verbose=verbose,
-            adr=adr)
+            adr=adr,
+        )
 
 
-def _scale_grid_data(points,
-                     values,
-                     xi,
-                     method='linear',
-                     fill_value=0,
-                     scale_factor=1.0):
-    return scale_factor * scipy.interpolate.griddata(
-        points, values, xi, method=method, fill_value=fill_value).T
+def _scale_grid_data(
+    points, values, xi, method="linear", fill_value=0, scale_factor=1.0
+):
+    return (
+        scale_factor
+        * scipy.interpolate.griddata(
+            points, values, xi, method=method, fill_value=fill_value
+        ).T
+    )
 
 
 def generate_wifes_cube_oneproc(
-    inimg, outimg,
+    inimg,
+    outimg,
     wire_fn,
     wsol_fn,
-    wmin_set = None, wmax_set = None, dw_set = None,
-    bin_x=None, bin_y=None,
+    wmin_set=None,
+    wmax_set=None,
+    dw_set=None,
+    bin_x=None,
+    bin_y=None,
     ny_orig=76,
     offset_orig=4,
     verbose=True,
-    adr=False):
-    #---------------------------
+    adr=False,
+):
+    # ---------------------------
     # check if halfframe
     halfframe = is_halfframe(inimg)
     if halfframe:
@@ -2708,7 +2937,7 @@ def generate_wifes_cube_oneproc(
     obs_hdr = f3[0].header
     # figure out the binning!
     try:
-        bin_temp = f3[1].header['CCDSUM'].split()
+        bin_temp = f3[1].header["CCDSUM"].split()
         default_bin_x = int(float(bin_temp[0]))
         default_bin_y = int(float(bin_temp[1]))
     except:
@@ -2722,19 +2951,19 @@ def generate_wifes_cube_oneproc(
     frame_wmin = 0.0
     frame_wmax = 20000.0
     frame_wdisps = []
-    for i in range(1,nslits+1):
+    for i in range(1, nslits + 1):
         f4 = pyfits.open(wsol_fn)
         wave = f4[i].data
         f4.close()
-        curr_wmin = numpy.max(numpy.min(wave,axis=1))
-        curr_wmax = numpy.min(numpy.max(wave,axis=1))
-        curr_wdisp = numpy.abs(numpy.mean(wave[:,1:]-wave[:,:-1]))
+        curr_wmin = numpy.max(numpy.min(wave, axis=1))
+        curr_wmax = numpy.min(numpy.max(wave, axis=1))
+        curr_wdisp = numpy.abs(numpy.mean(wave[:, 1:] - wave[:, :-1]))
         if curr_wmin > frame_wmin:
             frame_wmin = curr_wmin
         if curr_wmax < frame_wmax:
             frame_wmax = curr_wmax
         frame_wdisps.append(curr_wdisp)
-        #print numpy.shape(f3[i].data)
+        # print numpy.shape(f3[i].data)
     if dw_set != None:
         disp_ave = dw_set
     else:
@@ -2752,8 +2981,12 @@ def generate_wifes_cube_oneproc(
         final_frame_wmax = frame_wmax
 
     if verbose:
-        print(' Data spectral resolution (min/max):',numpy.round(numpy.min(frame_wdisps),4),numpy.round(numpy.max(frame_wdisps),4))
-        print(' Cube spectral resolution : ',disp_ave)
+        print(
+            " Data spectral resolution (min/max):",
+            numpy.round(numpy.min(frame_wdisps), 4),
+            numpy.round(numpy.max(frame_wdisps), 4),
+        )
+        print(" Cube spectral resolution : ", disp_ave)
 
     out_lambda = numpy.arange(final_frame_wmin, final_frame_wmax, disp_ave)
     # set up output data
@@ -2763,187 +2996,224 @@ def generate_wifes_cube_oneproc(
         wire_trans = f5[0].data
         f5.close()
     except:
-        wire_trans = numpy.zeros([ndy, ndx], dtype='d')+numpy.max(yarr)/2
-    #ny=70//bin_y+1
-    wire_offset = float(offset_orig)/float(bin_y)
-    ny=ny_orig//bin_y
-    nx=25
-    nlam=len(out_lambda)
+        wire_trans = numpy.zeros([ndy, ndx], dtype="d") + numpy.max(yarr) / 2
+    # ny=70//bin_y+1
+    wire_offset = float(offset_orig) / float(bin_y)
+    ny = ny_orig // bin_y
+    nx = 25
+    nlam = len(out_lambda)
     # for each slitlet...
-    init_out_y = numpy.arange(ny,dtype='d')
+    init_out_y = numpy.arange(ny, dtype="d")
     out_y = init_out_y - numpy.median(init_out_y)
     out_y_full, out_lambda_full = numpy.meshgrid(out_y, out_lambda)
-    #---------------------------
+    # ---------------------------
     # Prepare ADR corrections ...
-    if adr :
+    if adr:
         # observatory stuff
-        lat = obs_hdr['LAT-OBS'] # degrees
-        alt = obs_hdr['ALT-OBS'] # meters
-        dec = dec_dms2dd(obs_hdr['DEC'])
+        lat = obs_hdr["LAT-OBS"]  # degrees
+        alt = obs_hdr["ALT-OBS"]  # meters
+        dec = dec_dms2dd(obs_hdr["DEC"])
         # want to calculate average HA...
-        ha_start = obs_hdr['HA']
-        ha_end   = obs_hdr['HAEND']
-        ha = 0.5*(ha_degrees(ha_start)+
-                  ha_degrees(ha_end))
+        ha_start = obs_hdr["HA"]
+        ha_end = obs_hdr["HAEND"]
+        ha = 0.5 * (ha_degrees(ha_start) + ha_degrees(ha_end))
         # and average ZD...
-        zd_start = obs_hdr['ZD']
-        zd_end   = obs_hdr['ZDEND']
-        zd = numpy.radians(0.5*(zd_start+zd_end))
-        secz = 1.0/numpy.cos(zd)
+        zd_start = obs_hdr["ZD"]
+        zd_end = obs_hdr["ZDEND"]
+        zd = numpy.radians(0.5 * (zd_start + zd_end))
+        secz = 1.0 / numpy.cos(zd)
         tanz = numpy.tan(zd)
         # telescope PA!
-        telpa = numpy.radians(obs_hdr['TELPAN'])
+        telpa = numpy.radians(obs_hdr["TELPAN"])
         # THIS MUST BE A FIXED VALUE
-        adr_ref = adr_x_y(numpy.array([5600.0]),
-                          secz, ha, dec, lat, 
-                          teltemp = 0.0, telpres=700.0, telpa=telpa)
-    #---------------------------
+        adr_ref = adr_x_y(
+            numpy.array([5600.0]),
+            secz,
+            ha,
+            dec,
+            lat,
+            teltemp=0.0,
+            telpres=700.0,
+            telpa=telpa,
+        )
+    # ---------------------------
     # Create a temporary storage array for first iteration
-    flux_data_cube_tmp = numpy.zeros([nx,ny,nlam])
-    var_data_cube_tmp = numpy.ones([nx,ny,nlam])
-    dq_data_cube_tmp = numpy.ones([nx,ny,nlam])
+    flux_data_cube_tmp = numpy.zeros([nx, ny, nlam])
+    var_data_cube_tmp = numpy.ones([nx, ny, nlam])
+    dq_data_cube_tmp = numpy.ones([nx, ny, nlam])
     # First interpolation : Wavelength + y (=wire & ADR)
     if verbose:
-        print(' -> Step 1: interpolating along lambda and y (2D interp.)\r')
-        sys.stdout.write('\r 0%')
+        print(" -> Step 1: interpolating along lambda and y (2D interp.)\r")
+        sys.stdout.write("\r 0%")
         sys.stdout.flush()
-    for i in range(1,nslits+1):
+    for i in range(1, nslits + 1):
         f4 = pyfits.open(wsol_fn)
         wave = f4[i].data
         f4.close()
         curr_flux = f3[i].data
-        curr_var  = f3[25+i].data
-        curr_dq   = f3[50+i].data
+        curr_var = f3[25 + i].data
+        curr_dq = f3[50 + i].data
         # convert the *x* pixels to lambda
-        dw = numpy.abs(wave[:,1:]-wave[:,:-1])
+        dw = numpy.abs(wave[:, 1:] - wave[:, :-1])
         full_dw = numpy.zeros(numpy.shape(wave))
-        full_dw[:,1:] = dw
-        full_dw[:,0] = dw[:,0]
+        full_dw[:, 1:] = dw
+        full_dw[:, 0] = dw[:, 0]
         # and *y* to real y
-        curr_wire = wire_trans[i-1,:]
+        curr_wire = wire_trans[i - 1, :]
         all_ypos = full_y - curr_wire - wire_offset
         # from the y-lambda-flux data, interpolate the flux
         # for the desired output y-lambda grid
         wave_flat = wave.flatten()
         all_ypos_flat = all_ypos.flatten()
-        curr_flux_flat = (curr_flux/full_dw).flatten()
-        curr_var_flat  = (curr_var/full_dw**2).flatten()
-        curr_dq_flat   = curr_dq.flatten()
+        curr_flux_flat = (curr_flux / full_dw).flatten()
+        curr_var_flat = (curr_var / full_dw**2).flatten()
+        curr_dq_flat = curr_dq.flatten()
         # Calculate the ADR corrections (this is slow)
-        if adr :
-            adr = adr_x_y(wave_flat,secz, ha, dec, lat, teltemp = 0.0,
-                          telpres=700.0, telpa=telpa)
-            adr_y = adr[1]-adr_ref[1]
+        if adr:
+            adr = adr_x_y(
+                wave_flat, secz, ha, dec, lat, teltemp=0.0, telpres=700.0, telpa=telpa
+            )
+            adr_y = adr[1] - adr_ref[1]
             all_ypos_flat -= adr_y
         # Does the interpolation (this is equally slow ...)
-        flux_data_cube_tmp[i-1,:,:] = _scale_grid_data(
+        flux_data_cube_tmp[i - 1, :, :] = _scale_grid_data(
             (wave_flat, all_ypos_flat),
             curr_flux_flat,
             (out_lambda_full, out_y_full),
-            method='linear',
+            method="linear",
             fill_value=0.0,
-            scale_factor=disp_ave)
+            scale_factor=disp_ave,
+        )
 
-        var_data_cube_tmp[i-1,:,:] = _scale_grid_data(
+        var_data_cube_tmp[i - 1, :, :] = _scale_grid_data(
             (wave_flat, all_ypos_flat),
             curr_var_flat,
             (out_lambda_full, out_y_full),
-            method='linear',
+            method="linear",
             fill_value=0.0,
-            scale_factor=disp_ave ** 2)
+            scale_factor=disp_ave**2,
+        )
 
-        dq_data_cube_tmp[i-1,:,:] = _scale_grid_data(
+        dq_data_cube_tmp[i - 1, :, :] = _scale_grid_data(
             (wave_flat, all_ypos_flat),
             curr_dq_flat,
             (out_lambda_full, out_y_full),
-            method='nearest',
+            method="nearest",
             fill_value=1.0,
-            scale_factor=1.0)
+            scale_factor=1.0,
+        )
 
         if verbose:
             sys.stdout.flush()
-            sys.stdout.write('\r\r %d' % (i/(float(nslits))*100.) + '%')
+            sys.stdout.write("\r\r %d" % (i / (float(nslits)) * 100.0) + "%")
             sys.stdout.flush()
-            if i == nslits : sys.stdout.write('\n')
+            if i == nslits:
+                sys.stdout.write("\n")
     # Second interpolation : x (=ADR)
-    if adr :
+    if adr:
         # To avoid interpolation issues at the edges,
         # add two extra values on either side (0 in this version).
-        in_x = numpy.arange(-1,nslits+1,1, dtype='d') 
-        out_x = numpy.arange(nslits, dtype='d')
+        in_x = numpy.arange(-1, nslits + 1, 1, dtype="d")
+        out_x = numpy.arange(nslits, dtype="d")
         if verbose:
-            print(' -> Step 2: interpolating along x (1D interp.)')
-        for i in range(0,nlam) :
-            adr = adr_x_y(numpy.array([out_lambda[i]]),
-                          secz,ha,dec,lat, teltemp = 0.0, 
-                          telpres=700.0, 
-                          telpa=telpa)
+            print(" -> Step 2: interpolating along x (1D interp.)")
+        for i in range(0, nlam):
+            adr = adr_x_y(
+                numpy.array([out_lambda[i]]),
+                secz,
+                ha,
+                dec,
+                lat,
+                teltemp=0.0,
+                telpres=700.0,
+                telpa=telpa,
+            )
             adr_x = adr[0] - adr_ref[0]
-            for j in range(0,ny) :
+            for j in range(0, ny):
                 # here is the actual appending of 0 flux
                 this_flux = numpy.append(
                     numpy.append(
-                    flux_data_cube_tmp[0,j,i],
-                    flux_data_cube_tmp[:nslits,j,i]),
-                    flux_data_cube_tmp[nslits-1,j,i])
+                        flux_data_cube_tmp[0, j, i], flux_data_cube_tmp[:nslits, j, i]
+                    ),
+                    flux_data_cube_tmp[nslits - 1, j, i],
+                )
                 this_var = numpy.append(
                     numpy.append(
-                    var_data_cube_tmp[0,j,i],
-                    var_data_cube_tmp[:nslits,j,i]),
-                    var_data_cube_tmp[nslits-1,j,i])
+                        var_data_cube_tmp[0, j, i], var_data_cube_tmp[:nslits, j, i]
+                    ),
+                    var_data_cube_tmp[nslits - 1, j, i],
+                )
                 this_dq = numpy.append(
                     numpy.append(
-                    dq_data_cube_tmp[0,j,i],
-                    dq_data_cube_tmp[:nslits,j,i]),
-                    dq_data_cube_tmp[nslits-1,j,i])
+                        dq_data_cube_tmp[0, j, i], dq_data_cube_tmp[:nslits, j, i]
+                    ),
+                    dq_data_cube_tmp[nslits - 1, j, i],
+                )
                 # do interpolation
                 f = scipy.interpolate.interp1d(
-                    in_x-adr_x, this_flux, kind='linear', 
-                    fill_value=0.0, bounds_error=False)
+                    in_x - adr_x,
+                    this_flux,
+                    kind="linear",
+                    fill_value=0.0,
+                    bounds_error=False,
+                )
                 g = scipy.interpolate.interp1d(
-                    in_x-adr_x, this_var, kind='linear', 
-                    fill_value=0.0, bounds_error=False)
+                    in_x - adr_x,
+                    this_var,
+                    kind="linear",
+                    fill_value=0.0,
+                    bounds_error=False,
+                )
                 h = scipy.interpolate.interp1d(
-                    in_x-adr_x, this_dq, kind='nearest', 
-                    fill_value=3, bounds_error=False)
-                flux_data_cube_tmp[:nslits,j,i] = f(out_x)
-                var_data_cube_tmp[:nslits,j,i] = g(out_x)
-                dq_data_cube_tmp[:nslits,j,i] = h(out_x)
+                    in_x - adr_x,
+                    this_dq,
+                    kind="nearest",
+                    fill_value=3,
+                    bounds_error=False,
+                )
+                flux_data_cube_tmp[:nslits, j, i] = f(out_x)
+                var_data_cube_tmp[:nslits, j, i] = g(out_x)
+                dq_data_cube_tmp[:nslits, j, i] = h(out_x)
             if verbose:
-                if i > 0 :
+                if i > 0:
                     sys.stdout.flush()
-                sys.stdout.write('\r\r %d' % (i/(nlam-1.)*100.) + '%')
-                if i == nlam-1 :
-                    sys.stdout.write('\n')
+                sys.stdout.write("\r\r %d" % (i / (nlam - 1.0) * 100.0) + "%")
+                if i == nlam - 1:
+                    sys.stdout.write("\n")
     # All done, at last ! Now, let's save it all ...
     # ALWAYS ITERATE TO 25 EVEN IF HALFFRAME HERE!!
     outfits = pyfits.HDUList(f3)
-    for i in range(1,26):
+    for i in range(1, 26):
         # save to data cube
-        outfits[i].data = flux_data_cube_tmp[i-1,:,:]
-        outfits[i].header.set('CRVAL1', final_frame_wmin)
-        outfits[i].header.set('CDELT1', disp_ave)
-        outfits[i+25].data = var_data_cube_tmp[i-1,:,:]
-        outfits[i+50].data = dq_data_cube_tmp[i-1,:,:]
-        #outfits[i].header.set('NAXIS1', len(out_lambda))
-    outfits[0].header.set('PYWIFES', __version__, 'PyWiFeS version')
+        outfits[i].data = flux_data_cube_tmp[i - 1, :, :]
+        outfits[i].header.set("CRVAL1", final_frame_wmin)
+        outfits[i].header.set("CDELT1", disp_ave)
+        outfits[i + 25].data = var_data_cube_tmp[i - 1, :, :]
+        outfits[i + 50].data = dq_data_cube_tmp[i - 1, :, :]
+        # outfits[i].header.set('NAXIS1', len(out_lambda))
+    outfits[0].header.set("PYWIFES", __version__, "PyWiFeS version")
     outfits.writeto(outimg, overwrite=True)
     f3.close()
     return
 
 
 def generate_wifes_cube_multithread(
-    inimg, outimg,
+    inimg,
+    outimg,
     wire_fn,
     wsol_fn,
-    wmin_set = None, wmax_set = None, dw_set = None,
-    bin_x=None, bin_y=None,
+    wmin_set=None,
+    wmax_set=None,
+    dw_set=None,
+    bin_x=None,
+    bin_y=None,
     ny_orig=76,
     offset_orig=4,
     max_processes=-1,
     verbose=True,
-    adr=False):
-    #---------------------------
+    adr=False,
+):
+    # ---------------------------
     # check if halfframe
     halfframe = is_halfframe(inimg)
     if halfframe:
@@ -2959,7 +3229,7 @@ def generate_wifes_cube_multithread(
     obs_hdr = f3[0].header
     # figure out the binning!
     try:
-        bin_temp = f3[1].header['CCDSUM'].split()
+        bin_temp = f3[1].header["CCDSUM"].split()
         default_bin_x = int(float(bin_temp[0]))
         default_bin_y = int(float(bin_temp[1]))
     except:
@@ -2973,19 +3243,19 @@ def generate_wifes_cube_multithread(
     frame_wmin = 0.0
     frame_wmax = 20000.0
     frame_wdisps = []
-    for i in range(1,nslits+1):
+    for i in range(1, nslits + 1):
         f4 = pyfits.open(wsol_fn)
         wave = f4[i].data
         f4.close()
-        curr_wmin = numpy.max(numpy.min(wave,axis=1))
-        curr_wmax = numpy.min(numpy.max(wave,axis=1))
-        curr_wdisp = numpy.abs(numpy.mean(wave[:,1:]-wave[:,:-1]))
+        curr_wmin = numpy.max(numpy.min(wave, axis=1))
+        curr_wmax = numpy.min(numpy.max(wave, axis=1))
+        curr_wdisp = numpy.abs(numpy.mean(wave[:, 1:] - wave[:, :-1]))
         if curr_wmin > frame_wmin:
             frame_wmin = curr_wmin
         if curr_wmax < frame_wmax:
             frame_wmax = curr_wmax
         frame_wdisps.append(curr_wdisp)
-        #print numpy.shape(f3[i].data)
+        # print numpy.shape(f3[i].data)
     if dw_set != None:
         disp_ave = dw_set
     else:
@@ -3003,8 +3273,12 @@ def generate_wifes_cube_multithread(
         final_frame_wmax = frame_wmax
 
     if verbose:
-        print(' Data spectral resolution (min/max):',numpy.round(numpy.min(frame_wdisps),4),numpy.round(numpy.max(frame_wdisps),4))
-        print(' Cube spectral resolution : ',disp_ave)
+        print(
+            " Data spectral resolution (min/max):",
+            numpy.round(numpy.min(frame_wdisps), 4),
+            numpy.round(numpy.max(frame_wdisps), 4),
+        )
+        print(" Cube spectral resolution : ", disp_ave)
 
     out_lambda = numpy.arange(final_frame_wmin, final_frame_wmax, disp_ave)
     # set up output data
@@ -3014,246 +3288,280 @@ def generate_wifes_cube_multithread(
         wire_trans = f5[0].data
         f5.close()
     except:
-        wire_trans = numpy.zeros([ndy, ndx], dtype='d')+numpy.max(yarr)/2
-    #ny=70//bin_y+1
-    wire_offset = float(offset_orig)/float(bin_y)
-    ny=ny_orig//bin_y
-    nx=25
-    nlam=len(out_lambda)
+        wire_trans = numpy.zeros([ndy, ndx], dtype="d") + numpy.max(yarr) / 2
+    # ny=70//bin_y+1
+    wire_offset = float(offset_orig) / float(bin_y)
+    ny = ny_orig // bin_y
+    nx = 25
+    nlam = len(out_lambda)
     # for each slitlet...
-    init_out_y = numpy.arange(ny,dtype='d')
+    init_out_y = numpy.arange(ny, dtype="d")
     out_y = init_out_y - numpy.median(init_out_y)
     out_y_full, out_lambda_full = numpy.meshgrid(out_y, out_lambda)
-    #---------------------------
+    # ---------------------------
     # Prepare ADR corrections ...
-    if adr :
+    if adr:
         # observatory stuff
-        lat = obs_hdr['LAT-OBS'] # degrees
-        alt = obs_hdr['ALT-OBS'] # meters
-        dec = dec_dms2dd(obs_hdr['DEC'])
+        lat = obs_hdr["LAT-OBS"]  # degrees
+        alt = obs_hdr["ALT-OBS"]  # meters
+        dec = dec_dms2dd(obs_hdr["DEC"])
         # want to calculate average HA...
-        ha_start = obs_hdr['HA']
-        ha_end   = obs_hdr['HAEND']
-        ha = 0.5*(ha_degrees(ha_start)+
-                  ha_degrees(ha_end))
+        ha_start = obs_hdr["HA"]
+        ha_end = obs_hdr["HAEND"]
+        ha = 0.5 * (ha_degrees(ha_start) + ha_degrees(ha_end))
         # and average ZD...
-        zd_start = obs_hdr['ZD']
-        zd_end   = obs_hdr['ZDEND']
-        zd = numpy.radians(0.5*(zd_start+zd_end))
-        secz = 1.0/numpy.cos(zd)
+        zd_start = obs_hdr["ZD"]
+        zd_end = obs_hdr["ZDEND"]
+        zd = numpy.radians(0.5 * (zd_start + zd_end))
+        secz = 1.0 / numpy.cos(zd)
         tanz = numpy.tan(zd)
         # telescope PA!
-        telpa = numpy.radians(obs_hdr['TELPAN'])
+        telpa = numpy.radians(obs_hdr["TELPAN"])
         # THIS MUST BE A FIXED VALUE
-        adr_ref = adr_x_y(numpy.array([5600.0]),
-                          secz, ha, dec, lat, 
-                          teltemp = 0.0, telpres=700.0, telpa=telpa)
-    #---------------------------
+        adr_ref = adr_x_y(
+            numpy.array([5600.0]),
+            secz,
+            ha,
+            dec,
+            lat,
+            teltemp=0.0,
+            telpres=700.0,
+            telpa=telpa,
+        )
+    # ---------------------------
     # First interpolation : Wavelength + y (=wire & ADR)
     if verbose:
-        print(' -> Step 1: interpolating along lambda and y (2D interp.) MULTITHREAD\r')
+        print(" -> Step 1: interpolating along lambda and y (2D interp.) MULTITHREAD\r")
 
     tasks = []
-    for i in range(1,nslits+1):
+    for i in range(1, nslits + 1):
         f4 = pyfits.open(wsol_fn)
         wave = f4[i].data
         f4.close()
         curr_flux = f3[i].data
-        curr_var  = f3[25+i].data
-        curr_dq   = f3[50+i].data
+        curr_var = f3[25 + i].data
+        curr_dq = f3[50 + i].data
         # convert the *x* pixels to lambda
-        dw = numpy.abs(wave[:,1:]-wave[:,:-1])
+        dw = numpy.abs(wave[:, 1:] - wave[:, :-1])
         full_dw = numpy.zeros(numpy.shape(wave))
-        full_dw[:,1:] = dw
-        full_dw[:,0] = dw[:,0]
+        full_dw[:, 1:] = dw
+        full_dw[:, 0] = dw[:, 0]
         # and *y* to real y
-        curr_wire = wire_trans[i-1,:]
+        curr_wire = wire_trans[i - 1, :]
         all_ypos = full_y - curr_wire - wire_offset
         # from the y-lambda-flux data, interpolate the flux
         # for the desired output y-lambda grid
         wave_flat = wave.flatten()
         all_ypos_flat = all_ypos.flatten()
-        curr_flux_flat = (curr_flux/full_dw).flatten()
-        curr_var_flat  = (curr_var/full_dw**2).flatten()
-        curr_dq_flat   = curr_dq.flatten()
+        curr_flux_flat = (curr_flux / full_dw).flatten()
+        curr_var_flat = (curr_var / full_dw**2).flatten()
+        curr_dq_flat = curr_dq.flatten()
         # Calculate the ADR corrections (this is slow)
-        if adr :
-            adr = adr_x_y(wave_flat,secz, ha, dec, lat, teltemp = 0.0,
-                          telpres=700.0, telpa=telpa)
-            adr_y = adr[1]-adr_ref[1]
+        if adr:
+            adr = adr_x_y(
+                wave_flat, secz, ha, dec, lat, teltemp=0.0, telpres=700.0, telpa=telpa
+            )
+            adr_y = adr[1] - adr_ref[1]
             all_ypos_flat -= adr_y
 
         # Create tasks to calculate flux, var, and dq.
-        flux_task = get_task(_scale_grid_data,
-                            (wave_flat, all_ypos_flat),
-                            curr_flux_flat,
-                            (out_lambda_full, out_y_full),
-                            method='linear',
-                            fill_value=0.0,
-                            scale_factor=disp_ave)
+        flux_task = get_task(
+            _scale_grid_data,
+            (wave_flat, all_ypos_flat),
+            curr_flux_flat,
+            (out_lambda_full, out_y_full),
+            method="linear",
+            fill_value=0.0,
+            scale_factor=disp_ave,
+        )
 
-        var_task = get_task(_scale_grid_data,
-                            (wave_flat, all_ypos_flat),
-                            curr_var_flat,
-                            (out_lambda_full, out_y_full),
-                            method='linear',
-                            fill_value=0.0,
-                            scale_factor=disp_ave ** 2)
+        var_task = get_task(
+            _scale_grid_data,
+            (wave_flat, all_ypos_flat),
+            curr_var_flat,
+            (out_lambda_full, out_y_full),
+            method="linear",
+            fill_value=0.0,
+            scale_factor=disp_ave**2,
+        )
 
-        dq_task = get_task(_scale_grid_data,
-                            (wave_flat, all_ypos_flat),
-                            curr_dq_flat,
-                            (out_lambda_full, out_y_full),
-                            method='nearest',
-                            fill_value=1.0,
-                            scale_factor=1.0)
+        dq_task = get_task(
+            _scale_grid_data,
+            (wave_flat, all_ypos_flat),
+            curr_dq_flat,
+            (out_lambda_full, out_y_full),
+            method="nearest",
+            fill_value=1.0,
+            scale_factor=1.0,
+        )
 
         tasks.append(flux_task)
         tasks.append(var_task)
         tasks.append(dq_task)
     results = map_tasks(tasks, max_processes=max_processes)
 
-    #---------------------------
+    # ---------------------------
     # Create a temporary storage array for first iteration
-    flux_data_cube_tmp = numpy.zeros([nx,ny,nlam])
-    var_data_cube_tmp = numpy.ones([nx,ny,nlam])
-    dq_data_cube_tmp = numpy.ones([nx,ny,nlam])
+    flux_data_cube_tmp = numpy.zeros([nx, ny, nlam])
+    var_data_cube_tmp = numpy.ones([nx, ny, nlam])
+    dq_data_cube_tmp = numpy.ones([nx, ny, nlam])
 
     for i in range(nslits):
-        flux_data_cube_tmp[i,:,:] = results[3 * i]
-        var_data_cube_tmp[i,:,:] = results[3 * i + 1]
-        dq_data_cube_tmp[i,:,:] = results[3 * i + 2]
+        flux_data_cube_tmp[i, :, :] = results[3 * i]
+        var_data_cube_tmp[i, :, :] = results[3 * i + 1]
+        dq_data_cube_tmp[i, :, :] = results[3 * i + 2]
 
-    #---------------------------
+    # ---------------------------
     # Second interpolation : x (=ADR)
-    if adr :
+    if adr:
         # To avoid interpolation issues at the edges,
         # add two extra values on either side (0 in this version).
-        in_x = numpy.arange(-1,nslits+1,1, dtype='d') 
-        out_x = numpy.arange(nslits, dtype='d')
+        in_x = numpy.arange(-1, nslits + 1, 1, dtype="d")
+        out_x = numpy.arange(nslits, dtype="d")
         if verbose:
-            print(' -> Step 2: interpolating along x (1D interp.)')
-            sys.stdout.write('\r 0%')
+            print(" -> Step 2: interpolating along x (1D interp.)")
+            sys.stdout.write("\r 0%")
             sys.stdout.flush()
-        for i in range(0,nlam) :
-            adr = adr_x_y(numpy.array([out_lambda[i]]),
-                          secz,ha,dec,lat, teltemp = 0.0, 
-                          telpres=700.0, 
-                          telpa=telpa)
+        for i in range(0, nlam):
+            adr = adr_x_y(
+                numpy.array([out_lambda[i]]),
+                secz,
+                ha,
+                dec,
+                lat,
+                teltemp=0.0,
+                telpres=700.0,
+                telpa=telpa,
+            )
             adr_x = adr[0] - adr_ref[0]
-            for j in range(0,ny) :
+            for j in range(0, ny):
                 # here is the actual appending of 0 flux
                 this_flux = numpy.append(
                     numpy.append(
-                    flux_data_cube_tmp[0,j,i],
-                    flux_data_cube_tmp[:nslits,j,i]),
-                    flux_data_cube_tmp[nslits-1,j,i])
+                        flux_data_cube_tmp[0, j, i], flux_data_cube_tmp[:nslits, j, i]
+                    ),
+                    flux_data_cube_tmp[nslits - 1, j, i],
+                )
                 this_var = numpy.append(
                     numpy.append(
-                    var_data_cube_tmp[0,j,i],
-                    var_data_cube_tmp[:nslits,j,i]),
-                    var_data_cube_tmp[nslits-1,j,i])
+                        var_data_cube_tmp[0, j, i], var_data_cube_tmp[:nslits, j, i]
+                    ),
+                    var_data_cube_tmp[nslits - 1, j, i],
+                )
                 this_dq = numpy.append(
                     numpy.append(
-                    dq_data_cube_tmp[0,j,i],
-                    dq_data_cube_tmp[:nslits,j,i]),
-                    dq_data_cube_tmp[nslits-1,j,i])
+                        dq_data_cube_tmp[0, j, i], dq_data_cube_tmp[:nslits, j, i]
+                    ),
+                    dq_data_cube_tmp[nslits - 1, j, i],
+                )
                 # do interpolation
                 f = scipy.interpolate.interp1d(
-                    in_x-adr_x, this_flux, kind='linear', 
-                    fill_value=0.0, bounds_error=False)
+                    in_x - adr_x,
+                    this_flux,
+                    kind="linear",
+                    fill_value=0.0,
+                    bounds_error=False,
+                )
                 g = scipy.interpolate.interp1d(
-                    in_x-adr_x, this_var, kind='linear', 
-                    fill_value=0.0, bounds_error=False)
+                    in_x - adr_x,
+                    this_var,
+                    kind="linear",
+                    fill_value=0.0,
+                    bounds_error=False,
+                )
                 h = scipy.interpolate.interp1d(
-                    in_x-adr_x, this_dq, kind='nearest', 
-                    fill_value=3, bounds_error=False)
-                flux_data_cube_tmp[:nslits,j,i] = f(out_x)
-                var_data_cube_tmp[:nslits,j,i] = g(out_x)
-                dq_data_cube_tmp[:nslits,j,i] = h(out_x)
+                    in_x - adr_x,
+                    this_dq,
+                    kind="nearest",
+                    fill_value=3,
+                    bounds_error=False,
+                )
+                flux_data_cube_tmp[:nslits, j, i] = f(out_x)
+                var_data_cube_tmp[:nslits, j, i] = g(out_x)
+                dq_data_cube_tmp[:nslits, j, i] = h(out_x)
             if verbose:
-                if i > 0 :
+                if i > 0:
                     sys.stdout.flush()
-                sys.stdout.write('\r\r %d' % (i/(nlam-1.)*100.) + '%')
-                if i == nlam-1 :
-                    sys.stdout.write('\n')
+                sys.stdout.write("\r\r %d" % (i / (nlam - 1.0) * 100.0) + "%")
+                if i == nlam - 1:
+                    sys.stdout.write("\n")
     # All done, at last ! Now, let's save it all ...
     # ALWAYS ITERATE TO 25 EVEN IF HALFFRAME HERE!!
     outfits = pyfits.HDUList(f3)
-    for i in range(1,26):
+    for i in range(1, 26):
         # save to data cube
-        outfits[i].data = flux_data_cube_tmp[i-1,:,:]
-        outfits[i].header.set('CRVAL1', final_frame_wmin)
-        outfits[i].header.set('CDELT1', disp_ave)
-        outfits[i+25].data = var_data_cube_tmp[i-1,:,:]
-        outfits[i+50].data = dq_data_cube_tmp[i-1,:,:]
-        #outfits[i].header.set('NAXIS1', len(out_lambda))
-    outfits[0].header.set('PYWIFES', __version__, 'PyWiFeS version')
+        outfits[i].data = flux_data_cube_tmp[i - 1, :, :]
+        outfits[i].header.set("CRVAL1", final_frame_wmin)
+        outfits[i].header.set("CDELT1", disp_ave)
+        outfits[i + 25].data = var_data_cube_tmp[i - 1, :, :]
+        outfits[i + 50].data = dq_data_cube_tmp[i - 1, :, :]
+        # outfits[i].header.set('NAXIS1', len(out_lambda))
+    outfits[0].header.set("PYWIFES", __version__, "PyWiFeS version")
     outfits.writeto(outimg, overwrite=True)
     f3.close()
     return
 
 
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 def generate_wifes_3dcube(inimg, outimg):
     # load in data
     # assumes it is in pywifes format
     # otherwise why are you using this function
     f = pyfits.open(inimg)
     if len(f) == 76:
-            ny,nlam = numpy.shape(f[1].data)
-            nx=25
-            # get wavelength array
-            lam0 = f[1].header['CRVAL1']
-            dlam = f[1].header['CDELT1']
-            lam_array = lam0+dlam*numpy.arange(nlam,dtype='d')
-            # get data, variance and data quality
-            obj_cube_data = numpy.zeros([nlam,ny,nx],dtype='d')
-            obj_cube_var  = numpy.zeros([nlam,ny,nx],dtype='d')
-            obj_cube_dq   = numpy.zeros([nlam,ny,nx],dtype='d')
-            for i in range(nx):
-                curr_data = f[i+1].data
-                curr_var = f[i+26].data
-                curr_dq =f[i+51].data
-                obj_cube_data[:,:,nx-i-1] = curr_data.T
-                obj_cube_var[:,:,nx-i-1] = curr_var.T
-                obj_cube_dq[:,:,nx-i-1] = curr_dq.T
+        ny, nlam = numpy.shape(f[1].data)
+        nx = 25
+        # get wavelength array
+        lam0 = f[1].header["CRVAL1"]
+        dlam = f[1].header["CDELT1"]
+        lam_array = lam0 + dlam * numpy.arange(nlam, dtype="d")
+        # get data, variance and data quality
+        obj_cube_data = numpy.zeros([nlam, ny, nx], dtype="d")
+        obj_cube_var = numpy.zeros([nlam, ny, nx], dtype="d")
+        obj_cube_dq = numpy.zeros([nlam, ny, nx], dtype="d")
+        for i in range(nx):
+            curr_data = f[i + 1].data
+            curr_var = f[i + 26].data
+            curr_dq = f[i + 51].data
+            obj_cube_data[:, :, nx - i - 1] = curr_data.T
+            obj_cube_var[:, :, nx - i - 1] = curr_var.T
+            obj_cube_dq[:, :, nx - i - 1] = curr_dq.T
     else:
-            nlam, ny, nx = numpy.shape(f[1].data)
-            # get wavelength array
-            lam0 = f[1].header['CRVAL3']
-            dlam = f[1].header['CDELT3']
-            lam_array = lam0+dlam*numpy.arange(nlam,dtype='d')
-            # get data and variance
-            obj_cube_data = numpy.zeros([nlam,ny,nx],dtype='d')
-            obj_cube_var  = numpy.zeros([nlam,ny,nx],dtype='d')
-            obj_cube_dq   = numpy.zeros([nlam,ny,nx],dtype='d')
-            for i in range(nx):
-                curr_data = f[1].data[:,:,i]
-                curr_var = f[2].data[:,:,i]
-                curr_dq =f[3].data[:,:,i]
-                obj_cube_data[:,:,nx-i-1] = curr_data
-                obj_cube_var[:,:,nx-i-1] = curr_var
-                obj_cube_dq[:,:,nx-i-1] = curr_dq
-    
+        nlam, ny, nx = numpy.shape(f[1].data)
+        # get wavelength array
+        lam0 = f[1].header["CRVAL3"]
+        dlam = f[1].header["CDELT3"]
+        lam_array = lam0 + dlam * numpy.arange(nlam, dtype="d")
+        # get data and variance
+        obj_cube_data = numpy.zeros([nlam, ny, nx], dtype="d")
+        obj_cube_var = numpy.zeros([nlam, ny, nx], dtype="d")
+        obj_cube_dq = numpy.zeros([nlam, ny, nx], dtype="d")
+        for i in range(nx):
+            curr_data = f[1].data[:, :, i]
+            curr_var = f[2].data[:, :, i]
+            curr_dq = f[3].data[:, :, i]
+            obj_cube_data[:, :, nx - i - 1] = curr_data
+            obj_cube_var[:, :, nx - i - 1] = curr_var
+            obj_cube_dq[:, :, nx - i - 1] = curr_dq
+
     # ASTROMETRY: obtained from pointing
     # # Celestial coordinates
-    ra_str = f[1].header['RA']
-    dec_str = f[1].header['DEC']
+    ra_str = f[1].header["RA"]
+    dec_str = f[1].header["DEC"]
     # Convert celestial coordinates to degrees
     coord = SkyCoord(ra=ra_str, dec=dec_str, unit=(u.hourangle, u.deg))
-    crval1 = coord.ra.deg 
-    crval2 = coord.dec.deg 
+    crval1 = coord.ra.deg
+    crval2 = coord.dec.deg
     crval3 = lam0
-    
+
     # Set up a tangential projection
-    ctype1 = 'RA---TAN'
-    ctype2 = 'DEC--TAN'
-    ctype3 = 'WAVE'
+    ctype1 = "RA---TAN"
+    ctype2 = "DEC--TAN"
+    ctype3 = "WAVE"
 
     # Coordinate transformations
     # Telescope angle
-    telpa = f[1].header['TELPAN'] # in deg
+    telpa = f[1].header["TELPAN"]  # in deg
     telpa_radians = numpy.radians(telpa)  # in rad
     #  Calculate matrix elements for 3D rotation (around z-axis)
     cos_telpa = numpy.cos(telpa_radians)
@@ -3272,95 +3580,94 @@ def generate_wifes_3dcube(inimg, outimg):
     pc3_3 = 1.0
 
     # Equiv. to 1 pixel width in each axis' units
-    binning_2 = int(f[0].header['CCDSUM'][2])
-    arsec_deg = 0.00027777777777778   # 1 arcsecond in degrees
-    cdelt1 = -arsec_deg   
-    cdelt2 = arsec_deg/2*binning_2  
+    binning_2 = int(f[0].header["CCDSUM"][2])
+    arsec_deg = 0.00027777777777778  # 1 arcsecond in degrees
+    cdelt1 = -arsec_deg
+    cdelt2 = arsec_deg / 2 * binning_2
     cdelt3 = dlam
 
-    # Central pixel: defined in the centre of the central pixel   
-    crpix1 = nx/2 + 0.5  # Central pixel
-    crpix2 = ny/2 + 0.5 # Central pixel
+    # Central pixel: defined in the centre of the central pixel
+    crpix1 = nx / 2 + 0.5  # Central pixel
+    crpix2 = ny / 2 + 0.5  # Central pixel
     crpix3 = 1
 
     # Axis units
-    cunit1 = 'deg'
-    cunit2 = 'deg'
-    cunit3 = 'Angstrom'
+    cunit1 = "deg"
+    cunit2 = "deg"
+    cunit3 = "Angstrom"
 
     # save to data cube
     # DATA
-    cube_hdu = pyfits.PrimaryHDU(obj_cube_data, header = f[0].header)
+    cube_hdu = pyfits.PrimaryHDU(obj_cube_data, header=f[0].header)
     # Add header info
-    cube_hdu.header.set('CRVAL1',crval1, 'Value at ref. pixel on axis 1 (degrees)')
-    cube_hdu.header.set('CRVAL2',crval2, 'Value at ref. pixel on axis 2 (degrees)')
-    cube_hdu.header.set('CTYPE1',ctype1, 'Type of co-ordinate on axis 1')
-    cube_hdu.header.set('CTYPE2',ctype2, 'Type of co-ordinate on axis 2')
-    cube_hdu.header.set('CDELT1',cdelt1, 'RA axis pixel width (degrees)')
-    cube_hdu.header.set('CDELT2',cdelt2, 'Dec axis pixel width (degrees)')
-    cube_hdu.header.set('CRPIX1',crpix1, 'Reference pixel on axis 1')
-    cube_hdu.header.set('CRPIX2',crpix2, 'Reference pixel on axis 2')
-    cube_hdu.header.set('CRPIX2',crpix2, 'Reference pixel on axis 2')  
-    cube_hdu.header.set('PC1_1',pc1_1, 'Transformation matrix element')
-    cube_hdu.header.set('PC1_2',pc1_2, 'Transformation matrix element')
-    cube_hdu.header.set('PC2_1',pc2_1, 'Transformation matrix element')
-    cube_hdu.header.set('PC2_2',pc2_2, 'Transformation matrix element')
-    cube_hdu.header.set('CRVAL3',lam0, 'Reference wavelength (Angstroms)')
-    cube_hdu.header.set('CTYPE3',ctype3, 'Type of co-ordinate on axis 3')
-    cube_hdu.header.set('CDELT3',dlam, 'Wavelength step (Angstroms)')
-    cube_hdu.header.set('CRPIX3',crpix3, 'Reference pixel on wavelength (axis 3)')  
-    #cube_hdu.header.set('PYWIFES',__version__, 'Pywifes version'))
+    cube_hdu.header.set("CRVAL1", crval1, "Value at ref. pixel on axis 1 (degrees)")
+    cube_hdu.header.set("CRVAL2", crval2, "Value at ref. pixel on axis 2 (degrees)")
+    cube_hdu.header.set("CTYPE1", ctype1, "Type of co-ordinate on axis 1")
+    cube_hdu.header.set("CTYPE2", ctype2, "Type of co-ordinate on axis 2")
+    cube_hdu.header.set("CDELT1", cdelt1, "RA axis pixel width (degrees)")
+    cube_hdu.header.set("CDELT2", cdelt2, "Dec axis pixel width (degrees)")
+    cube_hdu.header.set("CRPIX1", crpix1, "Reference pixel on axis 1")
+    cube_hdu.header.set("CRPIX2", crpix2, "Reference pixel on axis 2")
+    cube_hdu.header.set("CRPIX2", crpix2, "Reference pixel on axis 2")
+    cube_hdu.header.set("PC1_1", pc1_1, "Transformation matrix element")
+    cube_hdu.header.set("PC1_2", pc1_2, "Transformation matrix element")
+    cube_hdu.header.set("PC2_1", pc2_1, "Transformation matrix element")
+    cube_hdu.header.set("PC2_2", pc2_2, "Transformation matrix element")
+    cube_hdu.header.set("CRVAL3", lam0, "Reference wavelength (Angstroms)")
+    cube_hdu.header.set("CTYPE3", ctype3, "Type of co-ordinate on axis 3")
+    cube_hdu.header.set("CDELT3", dlam, "Wavelength step (Angstroms)")
+    cube_hdu.header.set("CRPIX3", crpix3, "Reference pixel on wavelength (axis 3)")
+    # cube_hdu.header.set('PYWIFES',__version__, 'Pywifes version'))
     outfits = pyfits.HDUList([cube_hdu])
 
     # VARIANCE
-    var_hdu = pyfits.PrimaryHDU(obj_cube_var, header = f[0].header)
+    var_hdu = pyfits.PrimaryHDU(obj_cube_var, header=f[0].header)
     # Add header info
-    var_hdu.header.set('CRVAL1',crval1, 'Value at ref. pixel on axis 1 (degrees)')
-    var_hdu.header.set('CRVAL2',crval2, 'Value at ref. pixel on axis 2 (degrees)')
-    var_hdu.header.set('CTYPE1',ctype1, 'Type of co-ordinate on axis 1')
-    var_hdu.header.set('CTYPE2',ctype2, 'Type of co-ordinate on axis 2')
-    var_hdu.header.set('CDELT1',cdelt1, 'RA axis pixel width (degrees)')
-    var_hdu.header.set('CDELT2',cdelt2, 'Dec axis pixel width (degrees)')
-    var_hdu.header.set('CRPIX1',crpix1, 'Reference pixel on axis 1')
-    var_hdu.header.set('CRPIX2',crpix2, 'Reference pixel on axis 2')
-    var_hdu.header.set('CRPIX2',crpix2, 'Reference pixel on axis 2')  
-    var_hdu.header.set('PC1_1',pc1_1, 'Transformation matrix element')
-    var_hdu.header.set('PC1_2',pc1_2, 'Transformation matrix element')
-    var_hdu.header.set('PC2_1',pc2_1, 'Transformation matrix element')
-    var_hdu.header.set('PC2_2',pc2_2, 'Transformation matrix element')
-    var_hdu.header.set('CRVAL3',lam0, 'Reference wavelength (Angstroms)')
-    var_hdu.header.set('CTYPE3',ctype3, 'Type of co-ordinate on axis 3')
-    var_hdu.header.set('CDELT3',dlam, 'Wavelength step (Angstroms)')
-    var_hdu.header.set('CRPIX3',crpix3, 'Reference pixel on wavelength (axis 3)')  
-    #var_hdu.header.set('PYWIFES',__version__, 'Pywifes version')
+    var_hdu.header.set("CRVAL1", crval1, "Value at ref. pixel on axis 1 (degrees)")
+    var_hdu.header.set("CRVAL2", crval2, "Value at ref. pixel on axis 2 (degrees)")
+    var_hdu.header.set("CTYPE1", ctype1, "Type of co-ordinate on axis 1")
+    var_hdu.header.set("CTYPE2", ctype2, "Type of co-ordinate on axis 2")
+    var_hdu.header.set("CDELT1", cdelt1, "RA axis pixel width (degrees)")
+    var_hdu.header.set("CDELT2", cdelt2, "Dec axis pixel width (degrees)")
+    var_hdu.header.set("CRPIX1", crpix1, "Reference pixel on axis 1")
+    var_hdu.header.set("CRPIX2", crpix2, "Reference pixel on axis 2")
+    var_hdu.header.set("CRPIX2", crpix2, "Reference pixel on axis 2")
+    var_hdu.header.set("PC1_1", pc1_1, "Transformation matrix element")
+    var_hdu.header.set("PC1_2", pc1_2, "Transformation matrix element")
+    var_hdu.header.set("PC2_1", pc2_1, "Transformation matrix element")
+    var_hdu.header.set("PC2_2", pc2_2, "Transformation matrix element")
+    var_hdu.header.set("CRVAL3", lam0, "Reference wavelength (Angstroms)")
+    var_hdu.header.set("CTYPE3", ctype3, "Type of co-ordinate on axis 3")
+    var_hdu.header.set("CDELT3", dlam, "Wavelength step (Angstroms)")
+    var_hdu.header.set("CRPIX3", crpix3, "Reference pixel on wavelength (axis 3)")
+    # var_hdu.header.set('PYWIFES',__version__, 'Pywifes version')
     outfits.append(var_hdu)
-    
+
     # DQ
-    dq_hdu = pyfits.PrimaryHDU(obj_cube_dq, header = f[0].header)
+    dq_hdu = pyfits.PrimaryHDU(obj_cube_dq, header=f[0].header)
     # Add header info
-    dq_hdu.header.set('CRVAL1',crval1, 'Value at ref. pixel on axis 1 (degrees)')
-    dq_hdu.header.set('CRVAL2',crval2, 'Value at ref. pixel on axis 2 (degrees)')
-    dq_hdu.header.set('CTYPE1',ctype1, 'Type of co-ordinate on axis 1')
-    dq_hdu.header.set('CTYPE2',ctype2, 'Type of co-ordinate on axis 2')
-    dq_hdu.header.set('CDELT1',cdelt1, 'RA axis pixel width (degrees)')
-    dq_hdu.header.set('CDELT2',cdelt2, 'Dec axis pixel width (degrees)')
-    dq_hdu.header.set('CRPIX1',crpix1, 'Reference pixel on axis 1')
-    dq_hdu.header.set('CRPIX2',crpix2, 'Reference pixel on axis 2')
-    dq_hdu.header.set('CRPIX2',crpix2, 'Reference pixel on axis 2')  
-    dq_hdu.header.set('PC1_1',pc1_1, 'Transformation matrix element')
-    dq_hdu.header.set('PC1_2',pc1_2, 'Transformation matrix element')
-    dq_hdu.header.set('PC2_1',pc2_1, 'Transformation matrix element')
-    dq_hdu.header.set('PC2_2',pc2_2, 'Transformation matrix element')
-    dq_hdu.header.set('CRVAL3',lam0, 'Reference wavelength (Angstroms)')
-    dq_hdu.header.set('CTYPE3',ctype3, 'Type of co-ordinate on axis 3')
-    dq_hdu.header.set('CDELT3',dlam, 'Wavelength step (Angstroms)')
-    dq_hdu.header.set('CRPIX3',crpix3, 'Reference pixel on wavelength (axis 3)')  
-    #dq_hdu.header.set('PYWIFES',__version__, 'Pywifes version')
+    dq_hdu.header.set("CRVAL1", crval1, "Value at ref. pixel on axis 1 (degrees)")
+    dq_hdu.header.set("CRVAL2", crval2, "Value at ref. pixel on axis 2 (degrees)")
+    dq_hdu.header.set("CTYPE1", ctype1, "Type of co-ordinate on axis 1")
+    dq_hdu.header.set("CTYPE2", ctype2, "Type of co-ordinate on axis 2")
+    dq_hdu.header.set("CDELT1", cdelt1, "RA axis pixel width (degrees)")
+    dq_hdu.header.set("CDELT2", cdelt2, "Dec axis pixel width (degrees)")
+    dq_hdu.header.set("CRPIX1", crpix1, "Reference pixel on axis 1")
+    dq_hdu.header.set("CRPIX2", crpix2, "Reference pixel on axis 2")
+    dq_hdu.header.set("CRPIX2", crpix2, "Reference pixel on axis 2")
+    dq_hdu.header.set("PC1_1", pc1_1, "Transformation matrix element")
+    dq_hdu.header.set("PC1_2", pc1_2, "Transformation matrix element")
+    dq_hdu.header.set("PC2_1", pc2_1, "Transformation matrix element")
+    dq_hdu.header.set("PC2_2", pc2_2, "Transformation matrix element")
+    dq_hdu.header.set("CRVAL3", lam0, "Reference wavelength (Angstroms)")
+    dq_hdu.header.set("CTYPE3", ctype3, "Type of co-ordinate on axis 3")
+    dq_hdu.header.set("CDELT3", dlam, "Wavelength step (Angstroms)")
+    dq_hdu.header.set("CRPIX3", crpix3, "Reference pixel on wavelength (axis 3)")
+    # dq_hdu.header.set('PYWIFES',__version__, 'Pywifes version')
     outfits.append(dq_hdu)
-    
+
     # SAVE IT
-    outfits[0].header.set('PYWIFES', __version__, 'PyWiFeS version')
+    outfits[0].header.set("PYWIFES", __version__, "PyWiFeS version")
     outfits.writeto(outimg, overwrite=True)
     f.close()
     return
-

--- a/src/pywifes/wifes_calib.py
+++ b/src/pywifes/wifes_calib.py
@@ -432,7 +432,6 @@ def derive_wifes_calibration(cube_fn_list,
                                                     fill_value=numpy.nan)
     # first extract stdstar spectra and compare to reference
     fratio_results = []
-    print("cube_fn_list =" + repr(cube_fn_list))
     for i in range(len(cube_fn_list)):
         f = pyfits.open(cube_fn_list[i])
         cube_hdr = f[1].header

--- a/src/pywifes/wifes_calib.py
+++ b/src/pywifes/wifes_calib.py
@@ -702,7 +702,6 @@ def calibrate_wifes_cube(inimg, outimg,
     # calculate the flux calibration array
     if mode == 'pywifes':
         f1 = open(calib_fn, 'rb')
-        print('open rb')
         calib_info = pickle.load(f1)
         f1.close()
         sort_order = calib_info['wave'].argsort()


### PR DESCRIPTION
This pull request adds the ability to reduce data using master calibration files created from previous reductions. Moreover, the pipeline can now handle data sets where there are no object (science) or standard star observations. In such instances, the pipeline will generate calibration files exclusively. Users can activate these feature by specifying in the command line the `--from-master` or `-just-calib` flag, respectively. Detailed instructions for this setup are provided in the README.